### PR TITLE
Fix models refs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .cache/
 *.egg-info/
 *.pyc
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.egg-info/
 *.pyc
 /.idea
+/README
+/mystic/info.py
+/build

--- a/_examples/chebyshevinputs.py
+++ b/_examples/chebyshevinputs.py
@@ -11,8 +11,8 @@ chebyshevinputs.py -- cost function container module for NelderMeadSimplexSolver
 and PowellDirectionalSolver for testsolvers_pyre.py
 """
 
-from mystic.models.poly import chebyshev8cost as cost
-from mystic.models.poly import chebyshev8coeffs
+from models.poly import chebyshev8cost as cost
+from models.poly import chebyshev8coeffs
 from mystic.termination import *
 
 ND = 9

--- a/_examples/chebyshevinputs_de.py
+++ b/_examples/chebyshevinputs_de.py
@@ -11,7 +11,7 @@ chebychevinputs_de.py -- cost function container module for differential evoluti
 and the chebyshev function for testsolvers_pyre.py
 """
 
-from mystic.models.poly import chebyshev8cost as cost
+from models.poly import chebyshev8cost as cost
 from mystic.termination import *
 from mystic.strategy import *
 

--- a/_examples/derun.py
+++ b/_examples/derun.py
@@ -115,7 +115,7 @@ if __name__ == '__main__':
     app.run()
 
     # Chebyshev8 polynomial (used with "dummy.py")
-    from mystic.models.poly import chebyshev8coeffs as target_coeffs
+    from models.poly import chebyshev8coeffs as target_coeffs
     from mystic.math import poly1d
     print("target:\n%s" % poly1d(target_coeffs))
     print("\nDE Solution:\n%s" % poly1d(app.solution))

--- a/_examples/dummy.py
+++ b/_examples/dummy.py
@@ -10,7 +10,7 @@
 dummy.py -- cost function container module for derun.py
 """
 
-from mystic.models.poly import chebyshev8cost as cost
+from models.poly import chebyshev8cost as cost
 from mystic.termination import *
 from mystic.strategy import *
 

--- a/_examples/roseninputs.py
+++ b/_examples/roseninputs.py
@@ -10,7 +10,7 @@
 roseninputs.py -- inputs for testing the rosenbrock function for testsolvers_pyre.py
 """
 
-from mystic.models import rosen as cost
+from models import rosen as cost
 from mystic.termination import *
 
 ND = 3

--- a/_examples/sam_corana.py
+++ b/_examples/sam_corana.py
@@ -14,7 +14,7 @@ import sam, numpy, mystic
 from mystic.solvers import fmin
 from mystic.tools import getch
 
-from mystic.models.corana import corana1d as Corana1
+from models.corana import corana1d as Corana1
 
 x = numpy.arange(-2., 2., 0.01)
 y = [Corana1([c]) for c in x]

--- a/_examples/sam_corana2.py
+++ b/_examples/sam_corana2.py
@@ -20,7 +20,7 @@ from mystic.termination import CandidateRelativeTolerance as CRT
 from mystic.monitors import Monitor
 from mystic.tools import getch
 
-from mystic.models.corana import corana2d as Corana2
+from models.corana import corana2d as Corana2
 
 def draw_contour():
     import numpy

--- a/_examples/test_br8.py
+++ b/_examples/test_br8.py
@@ -19,9 +19,9 @@ from mystic.termination import ChangeOverGeneration, VTR
 from mystic.tools import getch, random_seed
 from mystic.monitors import VerboseMonitor as MyMonitor
 
-from mystic.models.br8 import decay; F = decay.ForwardFactory
-from mystic.models.br8 import cost as myCF
-from mystic.models.br8 import data
+from models.br8 import decay; F = decay.ForwardFactory
+from models.br8 import cost as myCF
+from models.br8 import data
 # evalpts = data[:,0], observations = data[:,1]
 
 def myshow():

--- a/_examples/testsolvers_pyre.py
+++ b/_examples/testsolvers_pyre.py
@@ -141,8 +141,8 @@ class TestSolverApp(Script):
 
 def output_chebyshev():
     # Chebyshev8 polynomial
-    from mystic.models.poly import chebyshev8coeffs as target_coeffs
-    from mystic.models.poly import poly1d
+    from models.poly import chebyshev8coeffs as target_coeffs
+    from models.poly import poly1d
     print("target:\n%s" % poly1d(target_coeffs))
     print("\nSolver Solution:\n%s" % poly1d(app.solution))
 

--- a/examples/README
+++ b/examples/README
@@ -1,5 +1,5 @@
 Files in this directory demonstrate basic use of mystic.  The most common
-case demonstrated is fitting a standard test function from mystic.models,
+case demonstrated is fitting a standard test function from models,
 however the use of constraints, the use of ensemble solvers, and the use
 of parallel computing is also demonstrated.
 

--- a/examples/TEST_ffitPP_b.py
+++ b/examples/TEST_ffitPP_b.py
@@ -25,7 +25,7 @@ def ChebyshevCost(trial,M=61):
     """The costfunction for order-n Chebyshev fitting.
 M evaluation points between [-1, 1], and two end points"""
 
-    from mystic.models.poly import chebyshev8coeffs as target
+    from models.poly import chebyshev8coeffs as target
     from mystic.math import polyeval
     result=0.0
     x=-1.0

--- a/examples/buckshot_example06.py
+++ b/examples/buckshot_example06.py
@@ -22,8 +22,8 @@ from mystic.solvers import BuckshotSolver
 from mystic.solvers import PowellDirectionalSolver
 
 # Chebyshev polynomial and cost function
-from mystic.models.poly import chebyshev8, chebyshev8cost
-from mystic.models.poly import chebyshev8coeffs
+from models.poly import chebyshev8, chebyshev8cost
+from models.poly import chebyshev8coeffs
 
 # if available, use a pathos worker pool
 try:

--- a/examples/constraint1_example01.py
+++ b/examples/constraint1_example01.py
@@ -20,7 +20,7 @@ Demonstrates:
 from mystic.solvers import fmin_powell
 
 # Rosenbrock function
-from mystic.models import rosen
+from models import rosen
 
 # tools
 from mystic.monitors import VerboseMonitor

--- a/examples/constraint2_example01.py
+++ b/examples/constraint2_example01.py
@@ -21,7 +21,7 @@ Demonstrates:
 from mystic.solvers import fmin_powell
 
 # Rosenbrock function
-from mystic.models import rosen
+from models import rosen
 
 # tools
 from mystic.monitors import VerboseMonitor

--- a/examples/constraint3_example01.py
+++ b/examples/constraint3_example01.py
@@ -21,7 +21,7 @@ Demonstrates:
 from mystic.solvers import fmin_powell
 
 # Rosenbrock function
-from mystic.models import rosen
+from models import rosen
 
 # tools
 from mystic.monitors import VerboseMonitor

--- a/examples/example01.py
+++ b/examples/example01.py
@@ -18,7 +18,7 @@ Demonstrates:
 from mystic.solvers import fmin_powell
 
 # Rosenbrock function
-from mystic.models import rosen
+from models import rosen
 
 
 if __name__ == '__main__':

--- a/examples/example02.py
+++ b/examples/example02.py
@@ -19,7 +19,7 @@ Demonstrates:
 from mystic.solvers import fmin
 
 # Rosenbrock function
-from mystic.models import rosen
+from models import rosen
 
 # tools
 import matplotlib.pyplot as plt

--- a/examples/example03.py
+++ b/examples/example03.py
@@ -20,7 +20,7 @@ Demonstrates:
 from mystic.solvers import fmin
 
 # Rosenbrock function
-from mystic.models import rosen
+from models import rosen
 
 # tools
 import matplotlib.pyplot as plt

--- a/examples/example04.py
+++ b/examples/example04.py
@@ -21,7 +21,7 @@ Demonstrates:
 from mystic.solvers import fmin
 
 # Rosenbrock function
-from mystic.models import rosen
+from models import rosen
 
 # tools
 from mystic.tools import getch

--- a/examples/example05.py
+++ b/examples/example05.py
@@ -20,7 +20,7 @@ Demonstrates:
 from mystic.solvers import fmin_powell
 
 # Rosenbrock function
-from mystic.models import rosen
+from models import rosen
 
 iter = 0
 # plot the parameter trajectories

--- a/examples/example06.py
+++ b/examples/example06.py
@@ -19,8 +19,8 @@ Demonstrates:
 from mystic.solvers import fmin_powell
 
 # Chebyshev polynomial and cost function
-from mystic.models.poly import chebyshev8, chebyshev8cost
-from mystic.models.poly import chebyshev8coeffs
+from models.poly import chebyshev8, chebyshev8cost
+from models.poly import chebyshev8coeffs
 
 # tools
 from mystic.math import poly1d

--- a/examples/example07.py
+++ b/examples/example07.py
@@ -20,8 +20,8 @@ Demonstrates:
 from mystic.solvers import diffev
 
 # Chebyshev polynomial and cost function
-from mystic.models.poly import chebyshev8, chebyshev8cost
-from mystic.models.poly import chebyshev8coeffs
+from models.poly import chebyshev8, chebyshev8cost
+from models.poly import chebyshev8coeffs
 
 # tools
 from mystic.math import poly1d

--- a/examples/example08.py
+++ b/examples/example08.py
@@ -24,8 +24,8 @@ Demonstrates:
 from mystic.solvers import DifferentialEvolutionSolver2
 
 # Chebyshev polynomial and cost function
-from mystic.models.poly import chebyshev8, chebyshev8cost
-from mystic.models.poly import chebyshev8coeffs
+from models.poly import chebyshev8, chebyshev8cost
+from models.poly import chebyshev8coeffs
 
 # tools
 from mystic.termination import VTR

--- a/examples/example09.py
+++ b/examples/example09.py
@@ -26,8 +26,8 @@ Demonstrates:
 from mystic.solvers import DifferentialEvolutionSolver2
 
 # Chebyshev polynomial and cost function
-from mystic.models.poly import chebyshev8, chebyshev8cost
-from mystic.models.poly import chebyshev8coeffs
+from models.poly import chebyshev8, chebyshev8cost
+from models.poly import chebyshev8coeffs
 
 # tools
 from mystic.termination import VTR

--- a/examples/example10.py
+++ b/examples/example10.py
@@ -24,8 +24,8 @@ Demonstrates:
 from mystic.solvers import DifferentialEvolutionSolver2
 
 # Chebyshev polynomial and cost function
-from mystic.models.poly import chebyshev8, chebyshev8cost
-from mystic.models.poly import chebyshev8coeffs
+from models.poly import chebyshev8, chebyshev8cost
+from models.poly import chebyshev8coeffs
 
 # tools
 from mystic.termination import VTR

--- a/examples/example11.py
+++ b/examples/example11.py
@@ -24,8 +24,8 @@ Demonstrates:
 from mystic.solvers import NelderMeadSimplexSolver
 
 # Chebyshev polynomial and cost function
-from mystic.models.poly import chebyshev8, chebyshev8cost
-from mystic.models.poly import chebyshev8coeffs
+from models.poly import chebyshev8, chebyshev8cost
+from models.poly import chebyshev8coeffs
 
 # tools
 from mystic.termination import CandidateRelativeTolerance as CRT

--- a/examples/ezmap_desolve.py
+++ b/examples/ezmap_desolve.py
@@ -40,7 +40,7 @@ from mystic.math import poly1d
 
 #from raw_chebyshev8 import chebyshev8cost as ChebyshevCost     # no globals
 #from raw_chebyshev8b import chebyshev8cost as ChebyshevCost    # use globals
-from mystic.models.poly import chebyshev8cost as ChebyshevCost  # no helper
+from models.poly import chebyshev8cost as ChebyshevCost  # no helper
 
 ND = 9
 NP = 40

--- a/examples/ezmap_desolve_rosen.py
+++ b/examples/ezmap_desolve_rosen.py
@@ -39,7 +39,7 @@ from mystic.monitors import VerboseMonitor
 from mystic.tools import random_seed
 
 #from raw_rosen import rosen as myCost     # with a helper function
-from mystic.models import rosen as myCost  # without a helper function
+from models import rosen as myCost  # without a helper function
 
 ND = 3
 NP = 20

--- a/examples/forward_model.py
+++ b/examples/forward_model.py
@@ -13,7 +13,7 @@ from mystic.forward_model import *
 
 
 if __name__=='__main__':
-    from mystic.models import mogi; ForwardMogiFactory = mogi.ForwardFactory
+    from models import mogi; ForwardMogiFactory = mogi.ForwardFactory
     import random
     from numpy import *
     xstations = array([random.uniform(-500,500) for i in range(300)])+1250.

--- a/examples/lattice_example06.py
+++ b/examples/lattice_example06.py
@@ -22,8 +22,8 @@ from mystic.solvers import LatticeSolver
 from mystic.solvers import PowellDirectionalSolver
 
 # Chebyshev polynomial and cost function
-from mystic.models.poly import chebyshev8, chebyshev8cost
-from mystic.models.poly import chebyshev8coeffs
+from models.poly import chebyshev8, chebyshev8cost
+from models.poly import chebyshev8coeffs
 
 # if available, use a pathos worker pool
 try:

--- a/examples/mpl_corana.py
+++ b/examples/mpl_corana.py
@@ -15,7 +15,7 @@ import matplotlib.pyplot as plt, numpy, mystic
 from mystic.solvers import fmin
 from mystic.tools import getch
 
-from mystic.models.storn import Corana
+from models.storn import Corana
 Corana1 = Corana(1)
 
 x = numpy.arange(-2., 2., 0.01)

--- a/examples/mpmap_desolve.py
+++ b/examples/mpmap_desolve.py
@@ -38,7 +38,7 @@ from mystic.math import poly1d
 
 #from raw_chebyshev8 import chebyshev8cost as ChebyshevCost     # no globals
 #from raw_chebyshev8b import chebyshev8cost as ChebyshevCost    # use globals
-from mystic.models.poly import chebyshev8cost as ChebyshevCost  # no helper
+from models.poly import chebyshev8cost as ChebyshevCost  # no helper
 
 ND = 9
 NP = 80

--- a/examples/mpmap_desolve_rosen.py
+++ b/examples/mpmap_desolve_rosen.py
@@ -36,7 +36,7 @@ from mystic.monitors import VerboseMonitor
 from mystic.tools import random_seed
 
 #from raw_rosen import rosen as myCost     # with a helper function
-from mystic.models import rosen as myCost  # without a helper function
+from models import rosen as myCost  # without a helper function
 
 ND = 3
 NP = 20

--- a/examples/raw_chebyshev8.py
+++ b/examples/raw_chebyshev8.py
@@ -15,7 +15,7 @@ def chebyshev8cost(trial,M=61):
     """The costfunction for order-n Chebyshev fitting.
 M evaluation points between [-1, 1], and two end points"""
 
-    from mystic.models.poly import chebyshev8coeffs as target
+    from models.poly import chebyshev8coeffs as target
     from mystic.math import polyeval
 
     result=0.0
@@ -36,7 +36,7 @@ M evaluation points between [-1, 1], and two end points"""
     return result
 
 if __name__=='__main__':
-    from mystic.models.poly import chebyshev8coeffs as target
+    from models.poly import chebyshev8coeffs as target
     from mystic.math import poly1d
     print(poly1d(target))
     print("")

--- a/examples/raw_chebyshev8b.py
+++ b/examples/raw_chebyshev8b.py
@@ -11,7 +11,7 @@ due to pickling issues, cost function is provided w/o using a factory method.
 (same as chebyshev8.py, except uses global target,polyeval,poly1d)
 """
 
-from mystic.models.poly import chebyshev8coeffs as target
+from models.poly import chebyshev8coeffs as target
 from mystic.math import polyeval, poly1d
 
 def chebyshev8cost(trial,M=61):

--- a/examples/restart_solver.py
+++ b/examples/restart_solver.py
@@ -10,7 +10,7 @@ from mystic.solvers import DifferentialEvolutionSolver
 from mystic.solvers import NelderMeadSimplexSolver
 from mystic.termination import VTR, ChangeOverGeneration, When, Or
 from mystic.monitors import VerboseMonitor
-from mystic.models import rosen
+from models import rosen
 from mystic.solvers import LoadSolver
 import dill
 import os

--- a/examples/test_circle.py
+++ b/examples/test_circle.py
@@ -19,7 +19,7 @@ The matplotlib output will draw
   -- the optimized circle with minimum R enclosing the points
 """
 
-from mystic.models import circle, sparse_circle
+from models import circle, sparse_circle
 import matplotlib.pyplot as plt
 
 # generate training set & define cost function

--- a/examples/test_corana.py
+++ b/examples/test_corana.py
@@ -25,8 +25,8 @@ from mystic.strategy import Best1Exp, Rand1Exp
 from mystic.tools import random_seed
 random_seed(123)
 
-from mystic.models import corana
-from mystic.models.storn import Corana as Corana1
+from models import corana
+from models.storn import Corana as Corana1
 corana1 = Corana1(1)
 
 ND = 4

--- a/examples/test_dejong3.py
+++ b/examples/test_dejong3.py
@@ -23,7 +23,7 @@ try: http://www.icsi.berkeley.edu/~storn/deshort1.ps
 
 from mystic.solvers import DifferentialEvolutionSolver
 from mystic.termination import ChangeOverGeneration, VTR
-from mystic.models.dejong import step as DeJong3
+from models.dejong import step as DeJong3
 
 from mystic.tools import random_seed
 random_seed(123)

--- a/examples/test_dejong4.py
+++ b/examples/test_dejong4.py
@@ -23,7 +23,7 @@ try: http://www.icsi.berkeley.edu/~storn/deshort1.ps
 from mystic.solvers import DifferentialEvolutionSolver
 from mystic.termination import ChangeOverGeneration, VTR
 from mystic.strategy import Best1Exp, Rand1Exp
-from mystic.models.dejong import quartic as DeJong4
+from models.dejong import quartic as DeJong4
 
 from mystic.tools import random_seed
 random_seed(123)

--- a/examples/test_dejong5.py
+++ b/examples/test_dejong5.py
@@ -21,7 +21,7 @@ Optimization 11: 341-359, 1997.
 from mystic.solvers import DifferentialEvolutionSolver
 from mystic.termination import ChangeOverGeneration, VTR
 from mystic.strategy import Best1Exp, Rand1Exp
-from mystic.models.dejong import shekel as DeJong5
+from models.dejong import shekel as DeJong5
 
 from mystic.tools import random_seed
 random_seed(123)

--- a/examples/test_ffit.py
+++ b/examples/test_ffit.py
@@ -31,8 +31,8 @@ from mystic.tools import random_seed
 random_seed(123)
 
 # get the target coefficients and cost function
-from mystic.models.poly import chebyshev8coeffs as Chebyshev8
-from mystic.models.poly import chebyshev8cost as ChebyshevCost
+from models.poly import chebyshev8coeffs as Chebyshev8
+from models.poly import chebyshev8cost as ChebyshevCost
 
 def print_solution(func):
     print(poly1d(func))

--- a/examples/test_ffit2.py
+++ b/examples/test_ffit2.py
@@ -21,13 +21,13 @@ from mystic.termination import ChangeOverGeneration, VTR
 from mystic.strategy import Best1Exp, Best1Bin, Rand1Exp, Best2Bin, Best2Exp
 from mystic.math import poly1d
 from mystic.monitors import VerboseMonitor
-from mystic.models.poly import chebyshev16cost
+from models.poly import chebyshev16cost
 
 from mystic.tools import random_seed
 random_seed(123)
 
 # get the target coefficients
-from mystic.models.poly import chebyshev16coeffs as Chebyshev16
+from models.poly import chebyshev16coeffs as Chebyshev16
 
 def ChebyshevCost(trial):
     """

--- a/examples/test_fosc3d.py
+++ b/examples/test_fosc3d.py
@@ -19,7 +19,7 @@ from mystic.strategy import Best1Exp, Best1Bin, Rand1Exp
 from mystic.tools import random_seed
 random_seed(123)
 
-from mystic.models import fosc3d as fOsc3D
+from models import fosc3d as fOsc3D
 
 def draw_contour():
     import matplotlib.pyplot as plt, numpy

--- a/examples/test_getCost.py
+++ b/examples/test_getCost.py
@@ -16,7 +16,7 @@ from mystic.strategy import *
 from forward_model import *
 
 from mystic.math import poly1d as ForwardPolyFactory
-from mystic.models import poly; PolyCostFactory = poly.CostFactory
+from models import poly; PolyCostFactory = poly.CostFactory
 from mystic.solvers import DifferentialEvolutionSolver
 from mystic.monitors import VerboseMonitor
 from mystic.tools import getch

--- a/examples/test_griewangk.py
+++ b/examples/test_griewangk.py
@@ -26,7 +26,7 @@ from mystic.tools import random_seed
 random_seed(123)
 
 # The costfunction for Griewangk's Function, Eq. (23) of [1].
-from mystic.models import griewangk as Griewangk_cost
+from models import griewangk as Griewangk_cost
 
 
 ND = 10

--- a/examples/test_lorentzian.py
+++ b/examples/test_lorentzian.py
@@ -13,7 +13,7 @@ Alternate fitting of a lorentzian peak (see test_lorentzian2.py)
 import matplotlib.pyplot as plt, matplotlib
 from numpy import *
 
-from mystic.models import lorentzian
+from models import lorentzian
 from test_lorentzian2 import *
 import warnings
 
@@ -79,7 +79,7 @@ if __name__ == '__main__':
     #NOTE: we will calculate the norm, not solve for it as a parameter
     target = [1., 45., -10., 20., 1., 0.1, 1.0] # norm set to 1.0
 
-    from mystic.models.lorentzian import gendata, histogram
+    from models.lorentzian import gendata, histogram
     npts = 4000; binwidth = 0.1
     N = npts * binwidth
     xmin, xmax = 0.0, 3.0

--- a/examples/test_lorentzian2.py
+++ b/examples/test_lorentzian2.py
@@ -26,7 +26,7 @@ random_seed(123)
 
 #matplotlib.interactive(True)
 
-from mystic.models import lorentzian
+from models import lorentzian
 F = lorentzian.ForwardFactory
 
 def show():
@@ -77,7 +77,7 @@ def de_solve(CF):
 if __name__ == '__main__':
     target = [1., 45., -10., 20., 1., 0.1, 120.]
 
-    from mystic.models.lorentzian import gendata, histogram
+    from models.lorentzian import gendata, histogram
     npts = 4000; binwidth = 0.1
     N = npts * binwidth
     xmin, xmax = 0.0, 3.0

--- a/examples/test_mogi.py
+++ b/examples/test_mogi.py
@@ -37,7 +37,7 @@ import numpy
 
 random_seed(123)
 
-from mystic.models import mogi; ForwardMogiFactory = mogi.ForwardFactory
+from models import mogi; ForwardMogiFactory = mogi.ForwardFactory
 
 # Let the "actual parameters" be :
 actual_params = [1234.,-500., 10., .1]

--- a/examples/test_peaks.py
+++ b/examples/test_peaks.py
@@ -12,7 +12,7 @@ Testing the 'Peaks" Function.
 (tests VTR when minimum has negative value)
 """
 from math import *
-from mystic.models import peaks
+from models import peaks
 
 nd = 2
 npop = 20

--- a/examples/test_rosenbrock.py
+++ b/examples/test_rosenbrock.py
@@ -20,7 +20,7 @@ test_rosenbrock*.py (or optimize.py in scipy.optimize).
 
 from mystic.solvers import DifferentialEvolutionSolver, diffev
 from mystic.termination import ChangeOverGeneration, VTR
-from mystic.models import rosen
+from models import rosen
 from mystic.monitors import Monitor, VerboseMonitor
 
 from mystic.tools import random_seed

--- a/examples/test_rosenbrock2.py
+++ b/examples/test_rosenbrock2.py
@@ -10,7 +10,7 @@
 example of using NelderMeadSimplexSolver on the rosenbrock function
 """
 
-from mystic.models import rosen
+from models import rosen
 import numpy
 
 if __name__=='__main__':

--- a/examples/test_rosenbrock3.py
+++ b/examples/test_rosenbrock3.py
@@ -10,7 +10,7 @@
 example of using PowellDirectionalSolver on the rosenbrock function
 """
 
-from mystic.models import rosen
+from models import rosen
 import numpy
 
 def constrain(x):

--- a/examples/test_rosenbrock3b.py
+++ b/examples/test_rosenbrock3b.py
@@ -10,7 +10,7 @@
 example of using DifferentialEvolutionSolver on the rosenbrock function
 """
 
-from mystic.models import rosen
+from models import rosen
 import numpy
 
 def constrain(x):

--- a/examples/test_wavy.py
+++ b/examples/test_wavy.py
@@ -22,7 +22,7 @@ from mystic.solvers import fmin
 from mystic.tools import random_seed
 random_seed(123)
 
-from mystic.models import wavy1, wavy2
+from models import wavy1, wavy2
 wavy = wavy1
 
 def show():

--- a/examples/test_zimmermann.py
+++ b/examples/test_zimmermann.py
@@ -29,7 +29,7 @@ from mystic.tools import random_seed
 random_seed(123)
 
 # Eq. (24-26) of [2].
-from mystic.models import zimmermann as CostFunction
+from models import zimmermann as CostFunction
 
 ND = 2
 NP = 20

--- a/examples3/collapse_bounds.py
+++ b/examples3/collapse_bounds.py
@@ -6,7 +6,7 @@
 #  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
 
 from mystic.solvers import DifferentialEvolutionSolver
-from mystic.models import rosen
+from models import rosen
 from mystic.tools import solver_bounds
 from mystic.termination import ChangeOverGeneration as COG, Or, CollapseCost
 from mystic.monitors import VerboseLoggingMonitor as Monitor

--- a/examples3/collapse_solver.py
+++ b/examples3/collapse_solver.py
@@ -18,8 +18,8 @@ from mystic.termination import ChangeOverGeneration as COG
 # also requires updated masks as input
 verbose = True#False
 
-#from mystic.models import rosen as model; target = 1.0
-from mystic.models import sphere as model; target = 0.0
+#from models import rosen as model; target = 1.0
+from models import sphere as model; target = 0.0
 n = 10
 
 #term = Or((COG(generations=300), CollapseAt(None, generations=100), CollapseAs(generations=100)))

--- a/examples3/sampler_pandas.py
+++ b/examples3/sampler_pandas.py
@@ -6,7 +6,7 @@
 #  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
 
 from ouq_models import WrapModel
-from mystic.models import rosen
+from models import rosen
 
 # generate a sampled dataset for the model
 model = WrapModel('rosen', rosen, cached=True)

--- a/examples3/test_searcher.py
+++ b/examples3/test_searcher.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
     traj = not stepmon # save all trajectories internally, if no logs
 
     # cost function
-    from mystic.models import griewangk as model
+    from models import griewangk as model
     ndim = 2  # model dimensionality
     bounds = ndim * [(-9.5,9.5)] # griewangk
 

--- a/examples3/test_searcher2.py
+++ b/examples3/test_searcher2.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
     traj = not evalmon # save all trajectories internally, if no logs
 
     # cost function
-    from mystic.models import griewangk as model
+    from models import griewangk as model
     ndim = 2  # model dimensionality
     bounds = ndim * [(-9.5,9.5)] # griewangk
 

--- a/examples3/test_surface.py
+++ b/examples3/test_surface.py
@@ -16,7 +16,7 @@ import time
 if __name__ == '__main__':
     start = time.time()
     """
-    from mystic.models import griewangk
+    from models import griewangk
     from mystic.termination import NormalizedChangeOverGeneration as NCOG
 
     stop = NCOG(1e-4)
@@ -68,7 +68,7 @@ if __name__ == '__main__':
     traj = not monitor # save all trajectories internally, if no logs
 
     # cost function
-    from mystic.models import griewangk as model
+    from models import griewangk as model
     ndim = 2  # model dimensionality
     bounds = ndim * [(-9.5,9.5)] # griewangk
 

--- a/examples4/TEST3.py
+++ b/examples4/TEST3.py
@@ -26,8 +26,8 @@ percent_change = 0.9
 # the model function
 # (similar to Simulation.cpp)
 #######################################################################
-from mystic.models.poly import poly1d
-from mystic.models.poly import chebyshev8coeffs as Chebyshev8
+from models.poly import poly1d
+from models.poly import chebyshev8coeffs as Chebyshev8
 from math import sin
 def function(x):
   """a 8th-order Chebyshev polynomial + sin + a constant

--- a/examples4/TEST3b.py
+++ b/examples4/TEST3b.py
@@ -26,8 +26,8 @@ percent_change = 0.9
 # the model function
 # (similar to Simulation.cpp)
 #######################################################################
-from mystic.models.poly import poly1d
-from mystic.models.poly import chebyshev8coeffs as Chebyshev8
+from models.poly import poly1d
+from models.poly import chebyshev8coeffs as Chebyshev8
 from math import sin
 def function(x):
   """a 8th-order Chebyshev polynomial + sin + a constant

--- a/models/functions.py
+++ b/models/functions.py
@@ -11,140 +11,140 @@ convert bound instances into functions
 """
 # from dejong import sphere, rosen, step, quartic, shekel
 def sphere(x):
-    from mystic.models.dejong import sphere; return sphere(x)
+    from models.dejong import sphere; return sphere(x)
 from .dejong import sphere as model
 sphere.__doc__ = model.__doc__
 
 def rosen(x):
-    from mystic.models.dejong import rosen; return rosen(x)
+    from models.dejong import rosen; return rosen(x)
 from .dejong import rosen as model
 rosen.__doc__ = model.__doc__
 
 def rosen0der(x):
-    from mystic.models.dejong import rosen0der; return rosen0der(x)
+    from models.dejong import rosen0der; return rosen0der(x)
 from .dejong import rosen0der as model
 rosen0der.__doc__ = model.__doc__
 
 def rosen1der(x):
-    from mystic.models.dejong import rosen1der; return rosen1der(x)
+    from models.dejong import rosen1der; return rosen1der(x)
 from .dejong import rosen1der as model
 rosen1der.__doc__ = model.__doc__
 
 def step(x):
-    from mystic.models.dejong import step; return step(x)
+    from models.dejong import step; return step(x)
 from .dejong import step as model
 step.__doc__ = model.__doc__
 
 def quartic(x):
-    from mystic.models.dejong import quartic; return quartic(x)
+    from models.dejong import quartic; return quartic(x)
 from .dejong import quartic as model
 quartic.__doc__ = model.__doc__
 
 def shekel(x):
-    from mystic.models.dejong import shekel; return shekel(x)
+    from models.dejong import shekel; return shekel(x)
 from .dejong import shekel as model
 shekel.__doc__ = model.__doc__
 
 # from storn import corana, griewangk, zimmermann
 def corana(x):
-    from mystic.models.storn import corana; return corana(x)
+    from models.storn import corana; return corana(x)
 from .storn import corana as model
 corana.__doc__ = model.__doc__
 
 def griewangk(x):
-    from mystic.models.storn import griewangk; return griewangk(x)
+    from models.storn import griewangk; return griewangk(x)
 from .storn import griewangk as model
 griewangk.__doc__ = model.__doc__
 
 def zimmermann(x):
-    from mystic.models.storn import zimmermann; return zimmermann(x)
+    from models.storn import zimmermann; return zimmermann(x)
 from .storn import zimmermann as model
 zimmermann.__doc__ = model.__doc__
 
 # from wolfram import fosc3d, nmin51
 def fosc3d(x):
-    from mystic.models.wolfram import fosc3d; return fosc3d(x)
+    from models.wolfram import fosc3d; return fosc3d(x)
 from .wolfram import fosc3d as model
 fosc3d.__doc__ = model.__doc__
 
 def nmin51(x):
-    from mystic.models.wolfram import nmin51; return nmin51(x)
+    from models.wolfram import nmin51; return nmin51(x)
 from .wolfram import nmin51 as model
 nmin51.__doc__ = model.__doc__
 
 # from nag import peaks
 def peaks(x):
-    from mystic.models.nag import peaks; return peaks(x)
+    from models.nag import peaks; return peaks(x)
 from .nag import peaks as model
 peaks.__doc__ = model.__doc__
 
 # from venkataraman import venkat91
 def venkat91(x):
-    from mystic.models.venkataraman import venkat91; return venkat91(x)
+    from models.venkataraman import venkat91; return venkat91(x)
 from .venkataraman import venkat91 as model
 venkat91.__doc__ = model.__doc__
 
 # from wavy import wavy1, wavy2
 def wavy1(x):
-    from mystic.models.wavy import wavy1; return wavy1(x)
+    from models.wavy import wavy1; return wavy1(x)
 from .wavy import wavy1 as model
 wavy1.__doc__ = model.__doc__
 
 def wavy2(x):
-    from mystic.models.wavy import wavy2; return wavy2(x)
+    from models.wavy import wavy2; return wavy2(x)
 from .wavy import wavy2 as model
 wavy2.__doc__ = model.__doc__
 
 # from pohlheim import schwefel, ellipsoid, rastrigin, powers, ackley
 # from pohlheim import michal, branins, easom, goldstein
 def schwefel(x):
-    from mystic.models.pohlheim import schwefel; return schwefel(x)
+    from models.pohlheim import schwefel; return schwefel(x)
 from .pohlheim import schwefel as model
 schwefel.__doc__ = model.__doc__
 
 def ellipsoid(x):
-    from mystic.models.pohlheim import ellipsoid; return ellipsoid(x)
+    from models.pohlheim import ellipsoid; return ellipsoid(x)
 from .pohlheim import ellipsoid as model
 ellipsoid.__doc__ = model.__doc__
 
 def rastrigin(x):
-    from mystic.models.pohlheim import rastrigin; return rastrigin(x)
+    from models.pohlheim import rastrigin; return rastrigin(x)
 from .pohlheim import rastrigin as model
 rastrigin.__doc__ = model.__doc__
 
 def powers(x):
-    from mystic.models.pohlheim import powers; return powers(x)
+    from models.pohlheim import powers; return powers(x)
 from .pohlheim import powers as model
 powers.__doc__ = model.__doc__
 
 def ackley(x):
-    from mystic.models.pohlheim import ackley; return ackley(x)
+    from models.pohlheim import ackley; return ackley(x)
 from .pohlheim import ackley as model
 ackley.__doc__ = model.__doc__
 
 def michal(x):
-    from mystic.models.pohlheim import michal; return michal(x)
+    from models.pohlheim import michal; return michal(x)
 from .pohlheim import michal as model
 michal.__doc__ = model.__doc__
 
 def branins(x):
-    from mystic.models.pohlheim import branins; return branins(x)
+    from models.pohlheim import branins; return branins(x)
 from .pohlheim import branins as model
 branins.__doc__ = model.__doc__
 
 def easom(x):
-    from mystic.models.pohlheim import easom; return easom(x)
+    from models.pohlheim import easom; return easom(x)
 from .pohlheim import easom as model
 easom.__doc__ = model.__doc__
 
 def goldstein(x):
-    from mystic.models.pohlheim import goldstein; return goldstein(x)
+    from models.pohlheim import goldstein; return goldstein(x)
 from .pohlheim import goldstein as model
 goldstein.__doc__ = model.__doc__
 
 # from schittkowski import paviani
 def paviani(x):
-    from mystic.models.schittkowski import paviani; return paviani(x)
+    from models.schittkowski import paviani; return paviani(x)
 from .schittkowski import paviani as model
 paviani.__doc__ = model.__doc__
 

--- a/models/poly.py
+++ b/models/poly.py
@@ -48,7 +48,7 @@ using numpy.poly1d(coeffs)"""
 
 
 # coefficients for specific Chebyshev polynomials
-from mystic.models._model_helper import chebyshev2coeffs, chebyshev4coeffs, \
+from models._model_helper import chebyshev2coeffs, chebyshev4coeffs, \
                       chebyshev6coeffs, chebyshev8coeffs, chebyshev16coeffs
 
 class Chebyshev(Polynomial):
@@ -102,7 +102,7 @@ def chebyshevcostfactory(target):
     def chebyshevcost(trial,M=61):
         """The costfunction for order-n Chebyshev fitting.
 M evaluation points between [-1, 1], and two end points"""
-        from mystic.models._model_helper import chebyshev
+        from models._model_helper import chebyshev
         return chebyshev(trial, target, M)
     return chebyshevcost
 
@@ -118,27 +118,27 @@ chebyshev16 = Chebyshev(16)
 def chebyshev2cost(trial,M=61):
     """The costfunction for order-n Chebyshev fitting.
 M evaluation points between [-1, 1], and two end points"""
-    from mystic.models._model_helper import chebyshev, chebyshev2coeffs
+    from models._model_helper import chebyshev, chebyshev2coeffs
     return chebyshev(trial, chebyshev2coeffs, M)
 def chebyshev4cost(trial,M=61):
     """The costfunction for order-n Chebyshev fitting.
 M evaluation points between [-1, 1], and two end points"""
-    from mystic.models._model_helper import chebyshev, chebyshev4coeffs
+    from models._model_helper import chebyshev, chebyshev4coeffs
     return chebyshev(trial, chebyshev4coeffs, M)
 def chebyshev6cost(trial,M=61):
     """The costfunction for order-n Chebyshev fitting.
 M evaluation points between [-1, 1], and two end points"""
-    from mystic.models._model_helper import chebyshev, chebyshev6coeffs
+    from models._model_helper import chebyshev, chebyshev6coeffs
     return chebyshev(trial, chebyshev6coeffs, M)
 def chebyshev8cost(trial,M=61):
     """The costfunction for order-n Chebyshev fitting.
 M evaluation points between [-1, 1], and two end points"""
-    from mystic.models._model_helper import chebyshev, chebyshev8coeffs
+    from models._model_helper import chebyshev, chebyshev8coeffs
     return chebyshev(trial, chebyshev8coeffs, M)
 def chebyshev16cost(trial,M=61):
     """The costfunction for order-n Chebyshev fitting.
 M evaluation points between [-1, 1], and two end points"""
-    from mystic.models._model_helper import chebyshev, chebyshev16coeffs
+    from models._model_helper import chebyshev, chebyshev16coeffs
     return chebyshev(trial, chebyshev16coeffs, M)
 
 

--- a/mystic/abstract_ensemble_solver.py
+++ b/mystic/abstract_ensemble_solver.py
@@ -26,7 +26,7 @@ Examples:
     A typical call to a 'ensemble' solver will roughly follow this example:
 
     >>> # the function to be minimized and the initial values
-    >>> from mystic.models import rosen
+    >>> from models import rosen
     >>> lb = [0.0, 0.0, 0.0]
     >>> ub = [2.0, 2.0, 2.0]
     >>> 

--- a/mystic/abstract_map_solver.py
+++ b/mystic/abstract_map_solver.py
@@ -25,7 +25,7 @@ Examples:
     A typical call to a 'map' solver will roughly follow this example:
 
     >>> # the function to be minimized and the initial values
-    >>> from mystic.models import rosen
+    >>> from models import rosen
     >>> lb = [0.0, 0.0, 0.0]
     >>> ub = [2.0, 2.0, 2.0]
     >>> 

--- a/mystic/abstract_solver.py
+++ b/mystic/abstract_solver.py
@@ -21,7 +21,7 @@ Examples:
     A typical call to a solver will roughly follow this example:
 
     >>> # the function to be minimized and the initial values
-    >>> from mystic.models import rosen
+    >>> from models import rosen
     >>> x0 = [0.8, 1.2, 0.7]
     >>> 
     >>> # get monitors and termination condition objects
@@ -46,7 +46,7 @@ Examples:
     An equivalent, but less flexible, call using the function interface is:
 
     >>> # the function to be minimized and the initial values
-    >>> from mystic.models import rosen
+    >>> from models import rosen
     >>> x0 = [0.8, 1.2, 0.7]
     >>> 
     >>> # configure the solver and obtain the solution

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -31,7 +31,7 @@ assert ip.gradient(x, f, method='linear').shape \
     == ip.gradient(x, fx, method='linear').shape
 
 
-from mystic.models import rosen0der as rosen
+from models import rosen0der as rosen
 y = rosen(x.T)
 
 f = ip.interpf(x, y, method='linear')

--- a/tests/test_method_order.py
+++ b/tests/test_method_order.py
@@ -6,7 +6,7 @@
 # License: 3-clause BSD.  The full license text is available at:
 #  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
 
-from mystic.models import rosen
+from models import rosen
 from mystic.solvers import *
 from mystic.termination import VTRChangeOverGeneration
 from mystic.monitors import VerboseMonitor, Monitor

--- a/tests/test_solver_best_performance.py
+++ b/tests/test_solver_best_performance.py
@@ -56,7 +56,7 @@ Time elapsed:  0.113857030869  seconds
     if verbose:
         print("Testing 2-D Rosenbrock:")
         print("Expected: x=[1., 1.] and f=0")
-    from mystic.models import rosen as costfunc
+    from models import rosen as costfunc
     ndim = 2
     lb = [-5.]*ndim
     ub = [5.]*ndim
@@ -199,7 +199,7 @@ Time elapsed:  32.8412370682  seconds
     if verbose:
         print("Testing Griewangk:")
         print("Expected: x=[0.]*10 and f=0")
-    from mystic.models import griewangk as costfunc
+    from models import griewangk as costfunc
     ndim = 10
     lb = [-400.]*ndim
     ub = [400.]*ndim

--- a/tests/test_solver_compare.py
+++ b/tests/test_solver_compare.py
@@ -15,7 +15,7 @@ except ImportError:
 scipy_solvers = ['fmin_powell', 'fmin']
 
 import mystic.solvers as solvers
-from mystic.models import rosen
+from models import rosen
 from mystic.math import almostEqual
 from mystic.monitors import VerboseMonitor
 from mystic.tools import random_seed

--- a/tests/test_solver_sanity.py
+++ b/tests/test_solver_sanity.py
@@ -38,7 +38,7 @@ class TestRosenbrock(unittest.TestCase):
     """Test the 2-dimensional rosenbrock optimization problem."""
 
     def setUp(self):
-        from mystic.models import rosen
+        from models import rosen
         self.costfunction = rosen
         self.exact=[1., 1.]
         self.NP = 40

--- a/tests/test_solver_state.py
+++ b/tests/test_solver_state.py
@@ -9,7 +9,7 @@
 from mystic.solvers import DifferentialEvolutionSolver
 from mystic.solvers import NelderMeadSimplexSolver, PowellDirectionalSolver
 from mystic.termination import VTR, ChangeOverGeneration, When, Or
-from mystic.models import rosen
+from models import rosen
 from mystic.solvers import LoadSolver
 import os
 import sys

--- a/tests/test_solver_suite.py
+++ b/tests/test_solver_suite.py
@@ -44,7 +44,7 @@ class TestZimmermann(unittest.TestCase):
     """Test the zimmermann optimization problem."""
 
     def setUp(self):
-        from mystic.models import zimmermann
+        from models import zimmermann
         self.costfunction = zimmermann
         self.expected=[7., 2.]
         self.ND = len(self.expected)
@@ -255,7 +255,7 @@ class TestRosenbrock(unittest.TestCase):
     """Test the 2-dimensional rosenbrock optimization problem."""
 
     def setUp(self):
-        from mystic.models import rosen
+        from models import rosen
         self.costfunction = rosen
         self.expected=[1., 1.]
         self.ND = len(self.expected)
@@ -460,7 +460,7 @@ class TestCorana(unittest.TestCase):
 minima."""
 
     def setUp(self):
-        from mystic.models import corana
+        from models import corana
         self.costfunction = corana
         self.ND = 4
         self.maxexpected=[0.05]*self.ND
@@ -664,7 +664,7 @@ class TestQuartic(unittest.TestCase):
     """Test the quartic (noisy) optimization problem."""
 
     def setUp(self):
-        from mystic.models import quartic
+        from models import quartic
         self.costfunction = quartic
         self.ND = 30
         self.expected=[0.]*self.ND
@@ -866,7 +866,7 @@ class TestShekel(unittest.TestCase):
     """Test the 5th DeJong function (Shekel) optimization problem."""
 
     def setUp(self):
-        from mystic.models import shekel
+        from models import shekel
         self.costfunction = shekel
         self.ND = 2
         self.expected=[-32., -32.]
@@ -1069,7 +1069,7 @@ class TestStep(unittest.TestCase):
     """Test the 3rd DeJong function (step) optimization problem."""
 
     def setUp(self):
-        from mystic.models import step
+        from models import step
         self.costfunction = step
         self.ND = 5
         self.expected = [-5.]*self.ND # xi=-5-n where n=[0.0,0.12]
@@ -1273,7 +1273,7 @@ class TestGriewangk(unittest.TestCase):
     """Test the Griewangk optimization problem."""
 
     def setUp(self):
-        from mystic.models import griewangk
+        from models import griewangk
         self.costfunction = griewangk
         self.ND = 10
         self.expected = [0.]*self.ND 
@@ -1476,7 +1476,7 @@ class TestPeaks(unittest.TestCase):
     """Test the peaks optimization problem."""
 
     def setUp(self):
-        from mystic.models import peaks
+        from models import peaks
         self.costfunction = peaks
         self.ND = 2
         self.expected = [0.23, -1.63]
@@ -1680,7 +1680,7 @@ class TestVenkataraman91(unittest.TestCase):
     """Test Venkataraman's sinc optimization problem."""
 
     def setUp(self):
-        from mystic.models import venkat91
+        from models import venkat91
         self.costfunction = venkat91
         self.ND = 2
         self.expected = [4., 4.]
@@ -1882,7 +1882,7 @@ class TestSchwefel(unittest.TestCase):
     """Test Schwefel's optimization problem."""
 
     def setUp(self):
-        from mystic.models import schwefel
+        from models import schwefel
         self.costfunction = schwefel
         self.ND = 2
         self.expected = [420.9687]*self.ND
@@ -2084,7 +2084,7 @@ class TestEasom(unittest.TestCase):
     """Test Easom's function."""
 
     def setUp(self):
-        from mystic.models import easom
+        from models import easom
         self.costfunction = easom
         self.ND = 2
         self.expected = [pi]*self.ND
@@ -2286,7 +2286,7 @@ class TestRotatedEllipsoid(unittest.TestCase):
     """Test the rotated ellipsoid function in 2 dimensions."""
 
     def setUp(self):
-        from mystic.models import ellipsoid
+        from models import ellipsoid
         self.costfunction = ellipsoid
         self.ND = 2
         self.expected = [0.]*self.ND
@@ -2488,7 +2488,7 @@ class TestAckley(unittest.TestCase):
     """Test Ackley's path function in 2 dimensions."""
 
     def setUp(self):
-        from mystic.models import ackley
+        from models import ackley
         self.costfunction = ackley
         self.ND = 2
         self.expected = [0.]*self.ND
@@ -2690,7 +2690,7 @@ class TestRastrigin(unittest.TestCase):
     """Test Rastrigin's function in 2 dimensions."""
 
     def setUp(self):
-        from mystic.models import rastrigin
+        from models import rastrigin
         self.costfunction = rastrigin
         self.ND = 2
         self.expected = [0.]*self.ND
@@ -2891,7 +2891,7 @@ class TestGoldsteinPrice(unittest.TestCase):
     """Test the Goldstein-Price function."""
 
     def setUp(self):
-        from mystic.models import goldstein
+        from models import goldstein
         self.costfunction = goldstein
         self.ND = 2
         self.expected = [0., -1.]
@@ -3094,7 +3094,7 @@ class TestChampion(unittest.TestCase):
     """Test Champion's NMinimize test function 51."""
 
     def setUp(self):
-        from mystic.models import nmin51
+        from models import nmin51
         self.costfunction = nmin51
         self.ND = 2
         self.expected = [-0.0244031,0.210612]
@@ -3297,7 +3297,7 @@ class TestPaviani(unittest.TestCase):
     """Test Paviani's function, or TP110 of Schittkowski's test problems."""
 
     def setUp(self):
-        from mystic.models import paviani
+        from models import paviani
         self.costfunction = paviani
         self.ND = 10
         self.x0 = [9.]*self.ND


### PR DESCRIPTION
This corrects the use imports from mystic.models to models throughout. Was necessary for examples to be run after a setup build. 