### PR TITLE
don't pass None as default to SetMapper

### DIFF
--- a/mystic/abstract_sampler.py
+++ b/mystic/abstract_sampler.py
@@ -57,7 +57,9 @@ Args:
         s.SetPenalty(self._kwds['penalty'])
         s.SetReducer(self._kwds['reducer'], arraylike=True)
         s.SetGenerationMonitor(self._kwds['stepmon']) #XXX: use self._stepmon?
-        s.SetMapper(self._kwds['map']) #TODO: close/join/clear after Solve?
+        mapper = self._kwds['map']
+        if mapper is not None: s.SetMapper(mapper)
+        #TODO: close/join/clear after Solve?
 
         # pass a copy of the monitor to all instances
         import copy


### PR DESCRIPTION
## Summary
`SetMapper` in `abstract_sampler` is set to take `None` as default.  Better is to skip `SetMapper` if no map is provided.  This avoids `solver._map` being set to `None` (causes issues at least in `examples3/xrd_optML3.py` and similar).
