### PR TITLE
add operators to normalize Distributions

### DIFF
--- a/mystic/tests/test_distribution.py
+++ b/mystic/tests/test_distribution.py
@@ -1,0 +1,19 @@
+from mystic.math import Distribution, almostEqual
+
+N = 100000
+a = Distribution('normal', 0, 1)
+b = Distribution('normal', 5, 3)
+c = Distribution('normal', 6, 6)
+
+apb = a+b
+a2pb2 = a/2+b/2
+apb2= (a+b)/2
+anb = Distribution(a,b)
+bnc = Distribution(b,c)
+bpc2 = (b+c)/2
+
+assert almostEqual(a2pb2(N).mean(), apb2(N).mean(), tol=.1)
+assert almostEqual(anb(N).mean(), .5*apb(N).mean(), tol=.1)
+assert almostEqual((a(N).mean() + b(N).mean())/2, apb2(N).mean(), tol=.1)
+assert almostEqual((b(N).mean() + c(N).mean())/2, bpc2(N).mean(), tol=.1)
+assert almostEqual((a+b+c)(N).mean(), (c+b+a)(N).mean(), tol=.1)


### PR DESCRIPTION
## Summary
remove normalization from `__add__`, and enable normalization through the keyword `norm` as well as the multiplication and division operators.

## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Added relevant documentation that builds in sphinx without error.
- [ ] Added new features that are documented with examples.
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added rationale for any breakage of backwards compatibility.