### PR TITLE
Distribution use numpy.random as default module

### DIFF
--- a/mystic/math/__init__.py
+++ b/mystic/math/__init__.py
@@ -130,7 +130,7 @@ note::
             d = getattr(rng, generator.__name__)
             self.rvs = lambda size=None: d(size=size, *args, **kwds)
             name = generator.__name__
-            mod = rng.__name__
+            mod = getattr(rng, '__name__', 'numpy.random') #XXX: bad default?
         name = "'{0}.{1}'".format(mod, name) if name else ""
         sig = ', '.join(str(i) for i in args) 
         kwd = ', '.join("{0}={1}".format(i,j) for i,j in kwds.items())

--- a/mystic/tests/test_distribution.py
+++ b/mystic/tests/test_distribution.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python
+#
+# Author: Mike McKerns (mmckerns @caltech and @uqfoundation)
+# Copyright (c) 2023 The Uncertainty Quantification Foundation.
+# License: 3-clause BSD.  The full license text is available at:
+#  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
+
 from mystic.math import Distribution, almostEqual
 
 N = 100000


### PR DESCRIPTION
## Summary
Distribution objects should use `numpy.random` as the default module when the `numpy.random` random state is used and the `numpy.random` function form is used.

## Checklist
**Documentation and Tests**
- [ ] Artifacts produced with the main branch work as expected under this PR.