### PR TITLE
drop formal support for python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: python
 
 matrix:
     include:
-        - python: '3.7'
-          env:
-
         - python: '3.8'
           env:
 
@@ -28,9 +25,6 @@ matrix:
             - CYTHON="true" # numpy source build
             - DILL="master"
             - KLEPTO="master"
-
-        - python: 'pypy3.7-7.3.9'
-          env:
 
         - python: 'pypy3.8-7.3.9' # at 7.3.11
           env:

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Requirements
 ------------
 ``mystic`` requires:
 
-* ``python`` (or ``pypy``), **>=3.7**
+* ``python`` (or ``pypy``), **>=3.8**
 * ``setuptools``, **>=42**
 * ``cython``, **>=0.29.30**
 * ``numpy``, **>=1.0**

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@
 import os
 import sys
 # drop support for older python
-if sys.version_info < (3, 7):
-    unsupported = 'Versions of Python before 3.7 are not supported'
+if sys.version_info < (3, 8):
+    unsupported = 'Versions of Python before 3.8 are not supported'
     raise ValueError(unsupported)
 
 # get distribution meta info
@@ -55,14 +55,13 @@ setup_kwds = dict(
         'Source Code':'https://github.com/uqfoundation/mystic',
         'Bug Tracker':'https://github.com/uqfoundation/mystic/issues',
     },
-    python_requires = '>=3.7',
+    python_requires = '>=3.8',
     classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,11 @@
 skip_missing_interpreters=
     True
 envlist =
-    py37-numpy12-sympy11
     py38-numpy12-sympy11
     py39-numpy12-sympy11
     py310-numpy12-sympy11
     py311-numpy12-sympy11
     py312-numpy12-sympy11
-    pypy37-numpy12-sympy11
     pypy38-numpy12-sympy11
     pypy39-numpy12-sympy11
     pypy310-numpy12-sympy11
@@ -18,13 +16,11 @@ setenv =
     PYTHONHASHSEED = 0
     recreate = True
 basepython = 
-    py37: python3.7
     py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
     py312: python3.12
-    pypy37: pypy37
     pypy38: pypy38
     pypy39: pypy39
     pypy310: pypy310


### PR DESCRIPTION
## Summary
Drop formal support for python 3.7

## Checklist
**Release Management**
- [x] Added rationale for any breakage of backwards compatibility.