### PR TITLE
expand specification of pts for ouq_model sampling

### DIFF
--- a/examples3/estimator.py
+++ b/examples3/estimator.py
@@ -361,7 +361,7 @@ if __name__ == '__main__':
 
     # generate some 'truth' data, using solver-directed sampling
     bounds = [(0,10)]*nx
-    data = golden.sample(bounds, pts=-4)
+    data = golden.sample(bounds, pts='4')
 
     # build an estimator instance 
     import mystic.monitors as mm

--- a/examples3/sampler_pandas.py
+++ b/examples3/sampler_pandas.py
@@ -11,7 +11,7 @@ from mystic.models import rosen
 # generate a sampled dataset for the model
 model = WrapModel('rosen', rosen, cached=True)
 bounds = [(0,10),(0,10)]
-data = model.sample(bounds, pts=-8)
+data = model.sample(bounds, pts='8')
 
 # plot the model and sampled data
 import mystic as my

--- a/examples3/test_error.py
+++ b/examples3/test_error.py
@@ -69,7 +69,7 @@ if __name__ == '__main__':
     print('max error: %s' % np.max(error, axis=-1))
 
     # calculate model error for 'golden'
-    data = golden.sample(bounds, pts=-4, map=pmap, axmap=smap)
+    data = golden.sample(bounds, pts='4', map=pmap, axmap=smap)
     #print('truth: %s' % str(golden([1,2,3,4,5])))
     estimate = dict(nx=nx, ny=ny, data=golden, noise=0, smooth=0)
     surrogate = InterpModel('surrogate', method='thin_plate', **estimate)
@@ -82,7 +82,7 @@ if __name__ == '__main__':
     #'''
     # sample more data, refit, and recalculate error
     print('resampling and refitting surrogate')
-    data = golden.sample(bounds, pts=-4, map=pmap, axmap=smap)
+    data = golden.sample(bounds, pts='4', map=pmap, axmap=smap)
     surrogate.fit()
     print('estimate: %s' % str(surrogate([1,2,3,4,5])))
     print('error: %s' % str(misfit([1,2,3,4,5])))

--- a/examples3/test_expected_error1.py
+++ b/examples3/test_expected_error1.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
     true = dict(mu=.01, sigma=0., zmu=-.01, zsigma=0.)
     truth = NoisyModel('truth', model=toy, nx=nx, ny=ny, **true)
     #print('sampling truth...')
-    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts=-16)
+    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts='16')
     Ns = 25 #XXX: number of samples, when model has randomness
 
     try: # parallel maps

--- a/examples3/test_expected_error1GP.py
+++ b/examples3/test_expected_error1GP.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
     true = dict(mu=.01, sigma=0., zmu=-.01, zsigma=0.)
     truth = NoisyModel('truth', model=toy, nx=nx, ny=ny, **true)
     #print('sampling truth...')
-    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts=-16)
+    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts='16')
     Ns = 25 #XXX: number of samples, when model has randomness
 
     try: # parallel maps

--- a/examples3/test_expected_error1ML.py
+++ b/examples3/test_expected_error1ML.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
     true = dict(mu=.01, sigma=0., zmu=-.01, zsigma=0.)
     truth = NoisyModel('truth', model=toy, nx=nx, ny=ny, **true)
     #print('sampling truth...')
-    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts=-16)
+    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts='16')
     Ns = 25 #XXX: number of samples, when model has randomness
 
     try: # parallel maps

--- a/examples3/test_expected_error2.py
+++ b/examples3/test_expected_error2.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
     true = dict(mu=.01, sigma=0., zmu=-.01, zsigma=0.)
     truth = NoisyModel('truth', model=toy, nx=nx, ny=ny, **true)
     #print('sampling truth...')
-    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts=-16)
+    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts='16')
     Ns = 25 #XXX: number of samples, when model has randomness
 
     try: # parallel maps

--- a/examples3/test_expected_error2GP.py
+++ b/examples3/test_expected_error2GP.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
     true = dict(mu=.01, sigma=0., zmu=-.01, zsigma=0.)
     truth = NoisyModel('truth', model=toy, nx=nx, ny=ny, **true)
     #print('sampling truth...')
-    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts=-16)
+    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts='16')
     Ns = 25 #XXX: number of samples, when model has randomness
 
     try: # parallel maps

--- a/examples3/test_expected_error2ML.py
+++ b/examples3/test_expected_error2ML.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
     true = dict(mu=.01, sigma=0., zmu=-.01, zsigma=0.)
     truth = NoisyModel('truth', model=toy, nx=nx, ny=ny, **true)
     #print('sampling truth...')
-    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts=-16)
+    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts='16')
     Ns = 25 #XXX: number of samples, when model has randomness
 
     try: # parallel maps

--- a/examples3/test_lub_expected_error1.py
+++ b/examples3/test_lub_expected_error1.py
@@ -85,7 +85,7 @@ if __name__ == '__main__':
     true = dict(mu=.01, sigma=0., zmu=-.01, zsigma=0.)
     truth = NoisyModel('truth', model=toy, nx=nx, ny=ny, **true)
     #print('sampling truth...')
-    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts=-16)
+    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts='16')
 
     # get initial guess, a monitor, and a counter
     import mystic._counter as it

--- a/examples3/test_lub_expected_error1GP.py
+++ b/examples3/test_lub_expected_error1GP.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
     true = dict(mu=.01, sigma=0., zmu=-.01, zsigma=0.)
     truth = NoisyModel('truth', model=toy, nx=nx, ny=ny, **true)
     #print('sampling truth...')
-    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts=-16)
+    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts='16')
 
     # get initial guess, a monitor, and a counter
     import mystic._counter as it

--- a/examples3/test_lub_expected_error1ML.py
+++ b/examples3/test_lub_expected_error1ML.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
     true = dict(mu=.01, sigma=0., zmu=-.01, zsigma=0.)
     truth = NoisyModel('truth', model=toy, nx=nx, ny=ny, **true)
     #print('sampling truth...')
-    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts=-16)
+    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts='16')
 
     # get initial guess, a monitor, and a counter
     import mystic._counter as it

--- a/examples3/test_lub_expected_error2a.py
+++ b/examples3/test_lub_expected_error2a.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
     true = dict(mu=.01, sigma=0., zmu=-.01, zsigma=0.)
     truth = NoisyModel('truth', model=toy, nx=nx, ny=ny, **true)
     #print('sampling truth...')
-    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts=-16)
+    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts='16')
 
     # build a model that approximates 'truth'
     #print('building model F(x|a) of truth...')

--- a/examples3/test_lub_expected_error2b.py
+++ b/examples3/test_lub_expected_error2b.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
     true = dict(mu=.01, sigma=0., zmu=-.01, zsigma=0.)
     truth = NoisyModel('truth', model=toy, nx=nx, ny=ny, **true)
     #print('sampling truth...')
-    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts=-16)
+    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts='16')
 
     # build a surrogate model by interpolating the data
     #print('building estimator G(x) from truth data...')

--- a/examples3/test_lub_expected_error2bGP.py
+++ b/examples3/test_lub_expected_error2bGP.py
@@ -87,7 +87,7 @@ if __name__ == '__main__':
     true = dict(mu=.01, sigma=0., zmu=-.01, zsigma=0.)
     truth = NoisyModel('truth', model=toy, nx=nx, ny=ny, **true)
     #print('sampling truth...')
-    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts=-16)
+    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts='16')
 
     # build a surrogate model by training on the data
     args = dict(alpha=1e-10, optimizer=None, n_restarts_optimizer=0)

--- a/examples3/test_lub_expected_error2bML.py
+++ b/examples3/test_lub_expected_error2bML.py
@@ -87,7 +87,7 @@ if __name__ == '__main__':
     true = dict(mu=.01, sigma=0., zmu=-.01, zsigma=0.)
     truth = NoisyModel('truth', model=toy, nx=nx, ny=ny, **true)
     #print('sampling truth...')
-    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts=-16)
+    data = truth.sample([(0,1),(1,10)]+[(0,10)]*(nx-2), pts='16')
 
     # build a surrogate model by training on the data
     args = dict(hidden_layer_sizes=(100,75,50,25),  max_iter=1000, n_iter_no_change=5, solver='lbfgs', learning_rate_init=0.001)

--- a/examples3/xrd_optML4x.py
+++ b/examples3/xrd_optML4x.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+#
+# Author: Mike McKerns (mmckerns @caltech and @uqfoundation)
+# Copyright (c) 2022-2023 The Uncertainty Quantification Foundation.
+# License: 3-clause BSD.  The full license text is available at:
+#  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
+#
+# adapted from XRD example at: https://spotlight.readthedocs.io/
+"""
+optimization of 4-input cost function using online learning of a surrogate
+"""
+import os
+from mystic.math.legacydata import dataset, datapoint
+from mystic.samplers import LatticeSampler
+from ouq_models import WrapModel, InterpModel
+from emulators import cost4 as cost, x4 as target, bounds4 as bounds
+#from mystic.cache.archive import file_archive, read as get_db
+
+# remove any prior cached evaluations of truth (i.e. an 'expensive' model)
+if os.path.exists("truth"):
+    import shutil
+    shutil.rmtree("truth")
+
+try: # parallel maps
+    from pathos.maps import Map
+    from pathos.pools import ProcessPool, ThreadPool, SerialPool
+    pmap = Map(SerialPool) #ProcessPool
+except ImportError:
+    pmap = None
+
+# generate a training dataset by sampling truth
+#archive = get_db('truth.db', type=file_archive)
+truth = WrapModel('truth', cost, nx=4, ny=None, cached=False)#archive)
+data = truth.sample(bounds, pts=[2, 1, 1, 1], pmap=map)#, archive=archive)
+
+# shutdown mapper
+if pmap is not None:
+    pmap.close(); pmap.join(); pmap.clear()
+
+# create an inexpensive surrogate for truth
+surrogate = InterpModel("surrogate", nx=4, ny=None, data=truth, smooth=0.0,
+                        noise=0.0, method="thin_plate", extrap=False)
+
+# iterate until mean error (of candidate minima) < 1e-3
+N = 4
+import numpy as np
+error = np.array([float('inf')])
+while error[:N].mean() > 1e-3:
+
+    # fit the surrogate to data in truth database
+    surrogate.fit(data=data)
+
+    # find the first-order critical points of the surrogate
+    surr_ = lambda x: surrogate(x, axis=None)
+    s = LatticeSampler(bounds, surr_, npts=N)
+    s.sample_until(terminated=all)
+    xdata = [list(i) for i in s._sampler._all_bestSolution]
+    ysurr = s._sampler._all_bestEnergy
+
+    _surr = lambda x: -surrogate(x, axis=None)
+    s_ = LatticeSampler(bounds, _surr, npts=N)
+    s_.sample_until(terminated=all)
+    xdata = xdata + [list(i) for i in s_._sampler._all_bestSolution]
+    ysurr = ysurr + [-i for i in s_._sampler._all_bestEnergy]
+
+    # evaluate truth at the same input as the surrogate critical points
+    ytrue = list(map(truth, xdata))
+
+    # compute absolute error between truth and surrogate at candidate extrema
+    error = abs(np.array(ytrue) - ysurr)
+    print("error@mins: %s" % error[:N])
+    print("error@maxs: %s" % error[-N:])
+    print("stop: %s; ave: %s; max: %s" % (error[:N].mean(), error.mean(), error.max()))
+
+    # add most recent candidate extrema to truth database
+    data.load(xdata, ytrue)
+
+# get minimum of last batch of results
+idx = np.argmin(ytrue)
+xnew = xdata[idx]
+ynew = ytrue[idx]
+
+# print the best parameters
+print(f"Best solution is {xnew} with Rwp {ynew}")
+print(f"Reference solution: {target}")
+ratios = [x / y for x, y in zip(target, xnew)]
+print(f"Ratios of best to reference solution: {ratios}")

--- a/examples3/xrd_optML4xs.py
+++ b/examples3/xrd_optML4xs.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Author: Mike McKerns (mmckerns @caltech and @uqfoundation)
+# Copyright (c) 2022-2023 The Uncertainty Quantification Foundation.
+# License: 3-clause BSD.  The full license text is available at:
+#  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
+#
+# adapted from XRD example at: https://spotlight.readthedocs.io/
+"""
+optimization of 4-input cost function using online learning of a surrogate
+"""
+import os
+from mystic.math.legacydata import dataset, datapoint
+from mystic.samplers import LatticeSampler
+from ouq_models import WrapModel, InterpModel
+from emulators import cost4 as cost, x4 as target, bounds4 as bounds
+from mystic.cache.archive import file_archive, read as get_db
+
+# remove any prior cached evaluations of truth (i.e. an 'expensive' model)
+if os.path.exists("truth"):
+    import shutil
+    shutil.rmtree("truth")
+
+# remove any prior cached evaluations of surrogate
+if os.path.exists("surrogate"):
+    import shutil
+    shutil.rmtree("surrogate")
+
+try: # parallel maps
+    from pathos.maps import Map
+    from pathos.pools import ProcessPool, ThreadPool, SerialPool
+    pmap = Map(SerialPool) #ProcessPool
+except ImportError:
+    pmap = None
+
+# generate a training dataset by sampling truth
+#archive = get_db('truth.db', type=file_archive)
+truth = WrapModel('truth', cost, nx=4, ny=None, cached=False)#archive)
+data = truth.sample(bounds, pts=[2, 1, 1, 1], pmap=map)#, archive=archive)
+
+# shutdown mapper
+if pmap is not None:
+    pmap.close(); pmap.join(); pmap.clear()
+
+# create an inexpensive surrogate for truth
+surrogate = InterpModel("surrogate", nx=4, ny=None, data=truth, smooth=0.0,
+                        noise=0.0, method="thin_plate", extrap=False)
+
+# iterate until mean error (of candidate minima) < 1e-3
+N = 4
+import numpy as np
+error = np.array([float('inf')])
+while error[:N].mean() > 1e-3:
+
+    # fit a new surrogate to data in truth database
+    get_db('surrogate').clear()
+    surrogate.fit(data=data)
+
+    # find the first-order critical points of the surrogate
+    surr = surrogate.sample(bounds, pts='.%s' % N)
+
+    # evaluate truth at the same input as the surrogate critical points
+    ytrue = list(map(truth, surr.coords))
+
+    # compute absolute error between truth and surrogate at candidate extrema
+    error = abs(np.array(ytrue) - surr.values)
+    print("error@mins: %s" % error[:N])
+    print("error@maxs: %s" % error[-N:])
+    print("stop: %s; ave: %s; max: %s" % (error[:N].mean(), error.mean(), error.max()))
+
+    # add most recent candidate extrema to truth database
+    data.load(surr.coords, ytrue)
+
+# get minimum of last batch of results
+idx = np.argmin(ytrue)
+xnew = surr.coords[idx]
+ynew = ytrue[idx]
+
+# print the best parameters
+print(f"Best solution is {xnew} with Rwp {ynew}")
+print(f"Reference solution: {target}")
+ratios = [x / y for x, y in zip(target, xnew)]
+print(f"Ratios of best to reference solution: {ratios}")


### PR DESCRIPTION
## Summary
The sampling in OUQModels is specified with `pts`, where `pts=4` would use traditional "random" sampling algorithms (here to sample 4 points), while a negative number would instead use optimizer-directed sampling -- thus, `pts=-4` would launch 4 minimizations and 4 maximizations.

Parsing a string is more flexible, so enable the use of strings to specify the use of optimizers.  Thus, `pts='4'` would be equivalent to `pts=-4`.  New capabilities are to be added, so that `pts='.4'` only returns the termini of the parameter trajectories (i.e. the best solution per solver), also `pts='+4'` only launches a search for maxima (here 4 maximizers) and `pts='-4'` only launches a search for minima (here 4 minimizers).

New examples are added to demonstrate the use of surrogate-assisted minimization, where maxima and minima are searched for on the surrogate -- explicitly using ensemble samplers and, alternately, using `surrogate.sample`.


## Checklist
**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Added relevant documentation that builds in sphinx without error.
- [x] Added new features that are documented with examples.
- [x] Artifacts produced with the main branch work as expected under this PR.