### PR TITLE
redefine 'e' in except block to avoid UnboundLocalError

### DIFF
--- a/mystic/constraints.py
+++ b/mystic/constraints.py
@@ -550,7 +550,8 @@ NOTE:
         for c in constraints:
             try:
                 ci = c(x[-1][:])
-            except ZeroDivisionError as e:
+            except ZeroDivisionError as exc:
+                e = exc
                 ci = x[-1][:] #XXX: do something else?
             x.append(ci.tolist() if hasattr(ci, 'tolist') else ci)
         if all(xi == x[-1] for xi in x[1:]) and e is None:
@@ -561,7 +562,8 @@ NOTE:
             e = None
             try:
                 ci = next(_constraints)(x[-1][:])
-            except ZeroDivisionError as e:
+            except ZeroDivisionError as exc:
+                e = exc
                 ci = x[-1][:] #XXX: do something else?
             x.append(ci.tolist() if hasattr(ci, 'tolist') else ci)
             if all(xi == x[-1] for xi in x[-n:]) and e is None:
@@ -615,7 +617,8 @@ NOTE:
         for c in constraints:
             try:
                 ci = c(x[0][:])
-            except ZeroDivisionError as e:
+            except ZeroDivisionError as exc:
+                e = exc
                 ci = x[0][:] #XXX: do something else?
             x.append(ci.tolist() if hasattr(ci, 'tolist') else ci)
             if x[-1] == x[0] and e is None:
@@ -626,7 +629,8 @@ NOTE:
             e = None
             try:
                 ci = next(_constraints)(x[-n][:])
-            except ZeroDivisionError as e:
+            except ZeroDivisionError as exc:
+                e = exc
                 ci = x[-n][:] #XXX: do something else?
             x.append(ci.tolist() if hasattr(ci, 'tolist') else ci)
             if x[-1] == x[-(n+1)] and e is None:


### PR DESCRIPTION
## Summary
fixes #216 
in the `_constraint` functions, `e = None` but is redefined when an exception occurs.
define `e` properly inside the `except` block to avoid the UnboundLocalError

## Checklist
**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added "Fixes #NNN" in the PR body, referencing the issue (#NNN) it closes.
- [x] Added a comment to issue #NNN, linking back to this PR.