### PR TITLE
formal support for python 3.12, build for 3.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,11 @@ matrix:
 
         - python: '3.11'
           env:
-            - CYTHON="true" # numpy source build
 
-        - python: '3.12-dev'
+        - python: '3.12'
+          env:
+
+        - python: '3.13-dev'
           env:
             - CYTHON="true" # numpy source build
             - DILL="master"
@@ -29,15 +31,15 @@ matrix:
         - python: 'pypy3.8-7.3.9' # at 7.3.11
           env:
 
-        - python: 'pypy3.9-7.3.9' # at 7.3.12
+        - python: 'pypy3.9-7.3.9' # at 7.3.13
           env:
 
-        - python: 'pypy3.10-7.3.12'
+        - python: 'pypy3.10-7.3.13'
           env:
 
     allow_failures:
-        - python: '3.12-dev'
-        - python: 'pypy3.10-7.3.12' # CI missing
+        - python: '3.13-dev'
+        - python: 'pypy3.10-7.3.13' # CI missing
     fast_finish: true
 
 cache:

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup_kwds = dict(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Scientific/Engineering',

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     py310-numpy12-sympy11
     py311-numpy12-sympy11
     py312-numpy12-sympy11
+    py313-numpy12-sympy11
     pypy38-numpy12-sympy11
     pypy39-numpy12-sympy11
     pypy310-numpy12-sympy11
@@ -21,6 +22,7 @@ basepython =
     py310: python3.10
     py311: python3.11
     py312: python3.12
+    py313: python3.13
     pypy38: pypy38
     pypy39: pypy39
     pypy310: pypy310


### PR DESCRIPTION
## Summary
add formal support for python 3.12, infrastructure to build python 3.13

## Checklist
**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Added relevant documentation that builds in sphinx without error.
- [ ] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [ ] Added rationale for any breakage of backwards compatibility.