### PR TITLE
fix #215: sort to better avoid complex in simplify

### DIFF
--- a/mystic/symbolic.py
+++ b/mystic/symbolic.py
@@ -733,10 +733,11 @@ Examples:
         variants = (100000,-200000,100100,-200,110,-20,11,-2,1) #HACK
         kwds['variants'] = list(variants)
         for sign in signs:
-            if equals(before,after,next(testvals),**kwds):
-                new = [after]
-            else:
-                new = [after.replace(cmp,flip(cmp))] #XXX: or flip(cmp,True)?
+            try:
+                eq = equals(before,after,next(testvals),**kwds)
+            except (ValueError, TypeError):
+                eq = True #XXX: if complex, don't flip... or compare square?
+            new = [after] if eq else [after.replace(cmp,flip(cmp))] #(cmp,True)?
             new.extend(z.replace('=',i) for (z,i) in zip(zro,sign))
             results.append(new)
 
@@ -753,9 +754,9 @@ Examples:
     eqns = []
     used = []
     for eqn in constraints.strip().split(NL):
-        # get least used, as they are likely to be simpler
+        # get least used (prefers no pow), as they are likely to be simpler
         vars = get_variables(eqn, variables)
-        vars.sort(key=eqn.count) #XXX: better to sort by count(var+'**')?
+        vars.sort(key=lambda x: (eqn.count(x), eqn.count(x+'**')))
         vars = target[:] if target else vars
         if cycle: vars = [var for var in vars if var not in used] + used
         while vars:


### PR DESCRIPTION
## Summary
fixes #215
instead of simplify sorting for least used, also include a second preference for minimal use of `**`.
secondarily, if error is thrown in checking if should flip the comparator, then pass (i.e. don't flip).

## Checklist
**Documentation and Tests**
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added "Fixes #NNN" in the PR body, referencing the issue (#NNN) it closes.
- [x] Added a comment to issue #NNN, linking back to this PR.
- [x] Added rationale for any breakage of backwards compatibility.