### PR TITLE
milder termination condition for optMLx example

### DIFF
--- a/examples3/xrd_optML3.py
+++ b/examples3/xrd_optML3.py
@@ -11,7 +11,7 @@ optimization of 3-input cost function using online learning of a surrogate
 """
 import os
 from mystic.solvers import diffev2
-from mystic.math.legacydata import dataset, datapoint
+from mystic.math.legacydata import datapoint
 from mystic.cache.archive import file_archive, read as get_db
 from ouq_models import WrapModel, InterpModel
 from emulators import cost3 as cost, x3 as target, bounds3 as bounds
@@ -42,14 +42,13 @@ surrogate = InterpModel("surrogate", nx=3, ny=None, data=truth, smooth=0.0,
 
 # iterate until error (of candidate minimum) < 1e-3
 error = float("inf")
-sign = 1.0
 while error > 1e-3:
 
     # fit the surrogate to data in truth database
     surrogate.fit(data=data)
 
     # find the minimum of the surrogate
-    results = diffev2(lambda x: sign * surrogate(x), bounds, npop=20,
+    results = diffev2(lambda x: surrogate(x), bounds, npop=20,
                       bounds=bounds, gtol=500, full_output=True)
 
     # evaluate truth at the same input as the surrogate minimum

--- a/examples3/xrd_optML3DT.py
+++ b/examples3/xrd_optML3DT.py
@@ -11,7 +11,7 @@ optimization of 3-input cost function using online learning of a surrogate
 """
 import os
 from mystic.solvers import diffev2
-from mystic.math.legacydata import dataset, datapoint
+from mystic.math.legacydata import datapoint
 from mystic.cache.archive import file_archive, read as get_db
 from ouq_models import WrapModel, LearnedModel
 from emulators import cost3 as cost, x3 as target, bounds3 as bounds
@@ -57,14 +57,13 @@ surrogate = LearnedModel('surrogate', nx=3, ny=None, data=truth, **mlkw)
 
 # iterate until error (of candidate minimum) < 1e-3
 error = float("inf")
-sign = 1.0
 while error > 1e-3:
 
     # fit the surrogate to data in truth database
     surrogate.fit(data=data)
 
     # find the minimum of the surrogate
-    results = diffev2(lambda x: sign * surrogate(x), bounds, npop=20,
+    results = diffev2(lambda x: surrogate(x), bounds, npop=20,
                       bounds=bounds, gtol=500, full_output=True)
 
     # evaluate truth at the same input as the surrogate minimum

--- a/examples3/xrd_optML3GP.py
+++ b/examples3/xrd_optML3GP.py
@@ -11,7 +11,7 @@ optimization of 3-input cost function using online learning of a surrogate
 """
 import os
 from mystic.solvers import diffev2
-from mystic.math.legacydata import dataset, datapoint
+from mystic.math.legacydata import datapoint
 from mystic.cache.archive import file_archive, read as get_db
 from ouq_models import WrapModel, LearnedModel
 from emulators import cost3 as cost, x3 as target, bounds3 as bounds
@@ -55,14 +55,13 @@ surrogate = LearnedModel('surrogate', nx=3, ny=None, data=truth, **mlkw)
 
 # iterate until error (of candidate minimum) < 1e-3
 error = float("inf")
-sign = 1.0
 while error > 1e-3:
 
     # fit the surrogate to data in truth database
     surrogate.fit(data=data)
 
     # find the minimum of the surrogate
-    results = diffev2(lambda x: sign * surrogate(x), bounds, npop=20,
+    results = diffev2(lambda x: surrogate(x), bounds, npop=20,
                       bounds=bounds, gtol=500, full_output=True)
 
     # evaluate truth at the same input as the surrogate minimum

--- a/examples3/xrd_optML3NN.py
+++ b/examples3/xrd_optML3NN.py
@@ -11,7 +11,7 @@ optimization of 3-input cost function using online learning of a surrogate
 """
 import os
 from mystic.solvers import diffev2
-from mystic.math.legacydata import dataset, datapoint
+from mystic.math.legacydata import datapoint
 from mystic.cache.archive import file_archive, read as get_db
 from ouq_models import WrapModel, LearnedModel
 from emulators import cost3 as cost, x3 as target, bounds3 as bounds
@@ -50,14 +50,13 @@ surrogate = LearnedModel('surrogate', nx=3, ny=None, data=truth, **mlkw)
 
 # iterate until error (of candidate minimum) < 1e-3
 error = float("inf")
-sign = 1.0
 while error > 1e-3:
 
     # fit the surrogate to data in truth database
     surrogate.fit(data=data)
 
     # find the minimum of the surrogate
-    results = diffev2(lambda x: sign * surrogate(x), bounds, npop=20,
+    results = diffev2(lambda x: surrogate(x), bounds, npop=20,
                       bounds=bounds, gtol=500, full_output=True)
 
     # evaluate truth at the same input as the surrogate minimum

--- a/examples3/xrd_optML4.py
+++ b/examples3/xrd_optML4.py
@@ -11,7 +11,7 @@ optimization of 4-input cost function using online learning of a surrogate
 """
 import os
 from mystic.solvers import diffev2
-from mystic.math.legacydata import dataset, datapoint
+from mystic.math.legacydata import datapoint
 from mystic.cache.archive import file_archive, read as get_db
 from ouq_models import WrapModel, InterpModel
 from emulators import cost4 as cost, x4 as target, bounds4 as bounds
@@ -42,14 +42,13 @@ surrogate = InterpModel("surrogate", nx=4, ny=None, data=truth, smooth=0.0,
 
 # iterate until error (of candidate minimum) < 1e-3
 error = float("inf")
-sign = 1.0
 while error > 1e-3:
 
     # fit the surrogate to data in truth database
     surrogate.fit(data=data)
 
     # find the minimum of the surrogate
-    results = diffev2(lambda x: sign * surrogate(x), bounds, npop=20,
+    results = diffev2(lambda x: surrogate(x), bounds, npop=20,
                       bounds=bounds, gtol=500, full_output=True)
 
     # evaluate truth at the same input as the surrogate minimum

--- a/examples3/xrd_optML4s.py
+++ b/examples3/xrd_optML4s.py
@@ -11,7 +11,7 @@ optimization of 4-input cost function using online learning of a surrogate
 """
 import os
 from mystic.solvers import diffev2
-from mystic.math.legacydata import dataset, datapoint
+from mystic.math.legacydata import datapoint
 from mystic.cache.archive import file_archive, read as get_db
 from ouq_models import WrapModel, InterpModel
 from emulators import cost4 as cost, x4 as target, bounds4 as bounds
@@ -48,7 +48,6 @@ surrogate = InterpModel("surrogate", nx=4, ny=None, data=truth, smooth=0.0,
 N = 4
 import numpy as np
 error = float("inf")
-sign = 1.0
 while error > 1e-3:
 
     # fit a new surrogate to data in truth database

--- a/examples3/xrd_optML4x.py
+++ b/examples3/xrd_optML4x.py
@@ -10,7 +10,6 @@
 optimization of 4-input cost function using online learning of a surrogate
 """
 import os
-from mystic.math.legacydata import dataset, datapoint
 from mystic.samplers import LatticeSampler
 from ouq_models import WrapModel, InterpModel
 from emulators import cost4 as cost, x4 as target, bounds4 as bounds
@@ -41,11 +40,12 @@ if pmap is not None:
 surrogate = InterpModel("surrogate", nx=4, ny=None, data=truth, smooth=0.0,
                         noise=0.0, method="thin_plate", extrap=False)
 
-# iterate until mean error (of candidate minima) < 1e-3
+# iterate until error (of candidate minimum) < 1e-3
 N = 4
 import numpy as np
-error = np.array([float('inf')])
-while error[:N].mean() > 1e-3:
+error = np.array([float('inf')]); idx = 0
+#while error[:N].mean() > 1e-3:
+while error[idx] > 1e-3:
 
     # fit the surrogate to data in truth database
     surrogate.fit(data=data)
@@ -67,16 +67,18 @@ while error[:N].mean() > 1e-3:
     ytrue = list(map(truth, xdata))
 
     # compute absolute error between truth and surrogate at candidate extrema
+    idx = np.argmin(ytrue)
     error = abs(np.array(ytrue) - ysurr)
-    print("error@mins: %s" % error[:N])
-    print("error@maxs: %s" % error[-N:])
-    print("stop: %s; ave: %s; max: %s" % (error[:N].mean(), error.mean(), error.max()))
+    #print("error@mins: %s" % error[:N])
+    #print("error@maxs: %s" % error[-N:])
+    print("ave: %s; max: %s" % (error.mean(), error.max()))
+    print("ave mins: %s; at min: %s" % (error[:N].mean(), error[idx]))
+    print("evaluations of truth: %s" % len(data))
 
     # add most recent candidate extrema to truth database
     data.load(xdata, ytrue)
 
 # get minimum of last batch of results
-idx = np.argmin(ytrue)
 xnew = xdata[idx]
 ynew = ytrue[idx]
 

--- a/examples3/xrd_optML4xs.py
+++ b/examples3/xrd_optML4xs.py
@@ -10,7 +10,6 @@
 optimization of 4-input cost function using online learning of a surrogate
 """
 import os
-from mystic.math.legacydata import dataset, datapoint
 from mystic.samplers import LatticeSampler
 from ouq_models import WrapModel, InterpModel
 from emulators import cost4 as cost, x4 as target, bounds4 as bounds
@@ -46,11 +45,12 @@ if pmap is not None:
 surrogate = InterpModel("surrogate", nx=4, ny=None, data=truth, smooth=0.0,
                         noise=0.0, method="thin_plate", extrap=False)
 
-# iterate until mean error (of candidate minima) < 1e-3
+# iterate until error (of candidate minimum) < 1e-3
 N = 4
 import numpy as np
-error = np.array([float('inf')])
-while error[:N].mean() > 1e-3:
+error = np.array([float('inf')]); idx = 0
+#while error[:N].mean() > 1e-3:
+while error[idx] > 1e-3:
 
     # fit a new surrogate to data in truth database
     get_db('surrogate').clear()
@@ -63,16 +63,18 @@ while error[:N].mean() > 1e-3:
     ytrue = list(map(truth, surr.coords))
 
     # compute absolute error between truth and surrogate at candidate extrema
+    idx = np.argmin(ytrue)
     error = abs(np.array(ytrue) - surr.values)
-    print("error@mins: %s" % error[:N])
-    print("error@maxs: %s" % error[-N:])
-    print("stop: %s; ave: %s; max: %s" % (error[:N].mean(), error.mean(), error.max()))
+    #print("error@mins: %s" % error[:N])
+    #print("error@maxs: %s" % error[-N:])
+    print("ave: %s; max: %s" % (error.mean(), error.max()))
+    print("ave mins: %s; at min: %s" % (error[:N].mean(), error[idx]))
+    print("evaluations of truth: %s" % len(data))
 
     # add most recent candidate extrema to truth database
     data.load(surr.coords, ytrue)
 
 # get minimum of last batch of results
-idx = np.argmin(ytrue)
 xnew = surr.coords[idx]
 ynew = ytrue[idx]
 


### PR DESCRIPTION
## Summary
use a milder, more consistent, termination for the optML"x" loop by looking at the error at the minimum.  Print other potential error metrics that are informative.  Other minor cleanup of optML examples.

## Checklist
**Documentation and Tests**
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [ ] Added rationale for any breakage of backwards compatibility.