### PR TITLE
catch TypeError when constraints produce complex number

### DIFF
--- a/mystic/constraints.py
+++ b/mystic/constraints.py
@@ -553,6 +553,12 @@ NOTE:
             except ZeroDivisionError as exc:
                 e = exc
                 ci = x[-1][:] #XXX: do something else?
+            except (TypeError, ValueError) as exc:
+                if (exc.args[0].find('not supported') and \
+                    exc.args[0].rfind("'complex'")):
+                    e = exc
+                    ci = x[-1][:] #XXX: do something else?
+                else: raise exc
             x.append(ci.tolist() if hasattr(ci, 'tolist') else ci)
         if all(xi == x[-1] for xi in x[1:]) and e is None:
             return x[-1] if onexit is None else onexit(x[-1][:])
@@ -565,6 +571,12 @@ NOTE:
             except ZeroDivisionError as exc:
                 e = exc
                 ci = x[-1][:] #XXX: do something else?
+            except (TypeError, ValueError) as exc:
+                if (exc.args[0].find('not supported') and \
+                    exc.args[0].rfind("'complex'")):
+                    e = exc
+                    ci = x[-1][:] #XXX: do something else?
+                else: raise exc
             x.append(ci.tolist() if hasattr(ci, 'tolist') else ci)
             if all(xi == x[-1] for xi in x[-n:]) and e is None:
                 return x[-1] if onexit is None else onexit(x[-1][:])
@@ -620,6 +632,12 @@ NOTE:
             except ZeroDivisionError as exc:
                 e = exc
                 ci = x[0][:] #XXX: do something else?
+            except (TypeError, ValueError) as exc:
+                if (exc.args[0].find('not supported') and \
+                    exc.args[0].rfind("'complex'")):
+                    e = exc
+                    ci = x[-1][:] #XXX: do something else?
+                else: raise exc
             x.append(ci.tolist() if hasattr(ci, 'tolist') else ci)
             if x[-1] == x[0] and e is None:
                 return x[-1] if onexit is None else onexit(x[-1][:])
@@ -632,6 +650,12 @@ NOTE:
             except ZeroDivisionError as exc:
                 e = exc
                 ci = x[-n][:] #XXX: do something else?
+            except (TypeError, ValueError) as exc:
+                if (exc.args[0].find('not supported') and \
+                    exc.args[0].rfind("'complex'")):
+                    e = exc
+                    ci = x[-1][:] #XXX: do something else?
+                else: raise exc
             x.append(ci.tolist() if hasattr(ci, 'tolist') else ci)
             if x[-1] == x[-(n+1)] and e is None:
                 return x[-1] if onexit is None else onexit(x[-1][:])
@@ -681,6 +705,11 @@ NOTE:
                     return x[:] if onexit is None else onexit(x[:])
             except ZeroDivisionError as e:
                 pass #XXX: do something else?
+            except (TypeError, ValueError) as exc:
+                if (exc.args[0].find('not supported') and \
+                    exc.args[0].rfind("'complex'")):
+                    pass #XXX: do something else?
+                else: raise exc
             x = [(i+rnd.randint(-1,1))*rnd.random() for i in x]
         # give up #XXX: or fail with Error?
         return x[:] if onfail is None else onfail(x[:])

--- a/mystic/symbolic.py
+++ b/mystic/symbolic.py
@@ -449,7 +449,7 @@ Args:
         try:
             after, before = eval(after,{},locals_), eval(before,{},locals_)
             break
-        except (ValueError,TypeError) as error:
+        except (ValueError, TypeError) as error:
             if (error.args[0].startswith('negative number') and \
                error.args[0].endswith('raised to a fractional power')) or \
                (error.args[0].find('not supported') and \
@@ -472,6 +472,7 @@ Args:
     else: #END HACK
         try:
             after, before = eval(after,{},locals_), eval(before,{},locals_)
+        #XXX: also catch TypeError here for complex numbers?
         except ZeroDivisionError as error:
             if errors: raise error
             try:


### PR DESCRIPTION
## Summary
a complex number can be produced from simplify and solve, and a TypeError will be thrown if an inequality is used with a complex number.  Avoid this by trying again.

## Checklist
**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Added relevant documentation that builds in sphinx without error.
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added a comment to issue #NNN, linking back to this PR.
- [x] Added rationale for any breakage of backwards compatibility.