### PR TITLE
avoid OverflowError and LinAlgError; pyina to 0.2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Optional requirements:
 * ``matplotlib``, **>=0.91**
 * ``scipy``, **>=0.6.0**
 * ``pathos``, **>=0.3.2**
-* ``pyina``, **>=0.2.8**
+* ``pyina``, **>=0.2.9**
 
 
 More Information

--- a/mystic/math/_rbf.py
+++ b/mystic/math/_rbf.py
@@ -132,28 +132,28 @@ class Rbf(object):
     """
 
     def _euclidean_norm(self, x1, x2):
-        return np.sqrt(((x1 - x2)**2).sum(axis=0))
+        return np.sqrt(np.square(x1 - x2).sum(axis=0))
 
     def _h_multiquadric(self, r):
-        return np.sqrt((1.0/self.epsilon*r)**2 + 1)
+        return np.sqrt(np.square(1.0/self.epsilon*r) + 1)
 
     def _h_inverse_multiquadric(self, r):
-        return 1.0/np.sqrt((1.0/self.epsilon*r)**2 + 1)
+        return 1.0/np.sqrt(np.square(1.0/self.epsilon*r) + 1)
 
     def _h_gaussian(self, r):
-        return np.exp(-(1.0/self.epsilon*r)**2)
+        return np.exp(-np.square(1.0/self.epsilon*r))
 
     def _h_linear(self, r):
         return r
 
     def _h_cubic(self, r):
-        return r**3
+        return np.power(r, 3)
 
     def _h_quintic(self, r):
-        return r**5
+        return np.power(r, 5)
 
     def _h_thin_plate(self, r):
-        return xlogy(r**2, r)
+        return xlogy(np.square(r), r)
 
     # Setup self._function and do smoke test on initial r
     def _init_function(self, r):

--- a/mystic/math/interpolate.py
+++ b/mystic/math/interpolate.py
@@ -468,7 +468,14 @@ def interpolate(x, z, xgrid, method=None, extrap=False, arrays=True, **kwds):
         si = _rbf
     if kind == 0: # 'rbf' -> Rbf
         import numpy as np
-        rbf = si.Rbf(*np.vstack((x.T, z)), function=function, **kwds)
+        if function in ('thin_plate', 'gaussian'):
+            rbf = np.vstack((x.T, z))
+            try: #XXX: don't try, just use _rbf?
+                rbf = si.Rbf(*rbf, function=function, **kwds)
+            except np.linalg.LinAlgError:
+                rbf = _rbf.Rbf(*rbf, function=function, **kwds)
+        else:
+            rbf = si.Rbf(*np.vstack((x.T, z)), function=function, **kwds)
         return _fx(rbf(*xgrid))
     # method = 'linear' -> LinearNDInterpolator
     # method = 'nearest' -> NearestNDInterpolator
@@ -534,6 +541,13 @@ def _interpf(x, z, method=None, extrap=False, arrays=False, **kwds):
         si = _rbf
     if kind == 0: # 'rbf'
         import numpy as np
+        if function in ('thin_plate', 'gaussian'):
+            rbf = np.vstack((x.T, z))
+            try: #XXX: don't try, just use _rbf?
+                rbf = si.Rbf(*rbf, function=function, **kwds)
+            except np.linalg.LinAlgError:
+                rbf = _rbf.Rbf(*rbf, function=function, **kwds)
+            return _f(rbf)
         return _f(si.Rbf(*np.vstack((x.T, z)), function=function, **kwds))
     elif x.ndim == 1: 
         return _f(si.interp1d(x, z, fill_value='extrapolate', bounds_error=False, kind=method))

--- a/mystic/math/samples.py
+++ b/mystic/math/samples.py
@@ -19,15 +19,17 @@ def _random_samples(lb, ub, npts=10000):
 generate npts random samples between given lb & ub
 
 Inputs:
-    lower bounds  --  a list of the lower bounds
-    upper bounds  --  a list of the upper bounds
-    npts  --  number of sample points [default = 10000]
+    lb -- a list of the lower bounds
+    ub -- a list of the upper bounds
+    npts -- number of sample points [default = 10000]
 """
   from mystic.tools import random_state
   dim = len(lb)
   pts = random_state(module='numpy.random').rand(dim,npts)
-  for i in range(dim):
-    pts[i] = (pts[i] * abs(ub[i] - lb[i])) + lb[i]
+  for i in range(dim): #XXX: use array operations?
+    lbi = lb[i]
+    ubi = ub[i]
+    pts[i] = (pts[i] * abs(ubi - lbi)) + lbi
   return pts  #XXX: returns a numpy.array
  #return [list(i) for i in pts]
 
@@ -37,11 +39,11 @@ def random_samples(lb, ub, npts=10000, dist=None, clip=False):
 generate npts samples from the given distribution between given lb & ub
 
 Inputs:
-    dist  --  a mystic.tools.Distribution instance (or list of Distributions)
-    lower bounds  --  a list of the lower bounds
-    upper bounds  --  a list of the upper bounds
-    npts  --  number of sample points [default = 10000]
-    clip  --  if True, clip at bounds, else resample [default = False]
+    lb -- a list of the lower bounds
+    ub -- a list of the upper bounds
+    npts -- number of sample points [default = 10000]
+    dist -- a mystic.tools.Distribution instance (or list of Distributions)
+    clip -- if True, clip at bounds, else resample [default = False]
 """
   if dist is None:
     return _random_samples(lb,ub, npts)

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ class BinaryDistribution(Distribution):
 dill_version = 'dill>=0.3.8'
 klepto_version = 'klepto>=0.2.5'
 pathos_version = 'pathos>=0.3.2'
-pyina_version = 'pyina>=0.2.8'
+pyina_version = 'pyina>=0.2.9'
 cython_version = 'cython>=0.29.30' #XXX: required to build numpy from source
 numpy_version = 'numpy>=1.0'
 sympy_version = 'sympy>=0.6.7'#, <0.7.4'


### PR DESCRIPTION
## Summary
- bump pyina to 0.2.9
- use `np.square(r)` and `np.power(r, n)` instead of `r**2` and `r**n` to avoid `OverflowError`
- use `mystic.math.rbf` instead of `scipy.interpolate.rbf` for `thin_plate` when throws `LinAlgError`
- corrected docs in `mystic.math.sample` to match arg names

## Checklist

<!-- Please delete any checkboxes that do not apply to this PR. -->

**Documentation and Tests**
- [x] Added relevant documentation that builds in sphinx without error.
- [x] Artifacts produced with the main branch work as expected under this PR.
