### PR TITLE
avoid ZeroDivision and LinAlgError for single datapoint

### DIFF
--- a/examples3/dataset.py
+++ b/examples3/dataset.py
@@ -53,7 +53,8 @@ def interpolate(data, step=None, **kwds):
     NOTE:
       additional keyword arguments (epsilon, smooth, norm) are avaiable
       for use with a Rbf interpolator. See mystic.math.interpolate.Rbf
-      for more details.
+      for more details. if initialization produces a singlular matrix,
+      try non-zero smooth.
     """
     # interpolate for each member of tuple-valued data, unless axis provided
     axis = kwds.pop('axis', None) # axis for tuple-valued data

--- a/examples3/interpolator.py
+++ b/examples3/interpolator.py
@@ -54,7 +54,8 @@ class Interpolator(object):
         NOTE:
           additional keyword arguments (epsilon, smooth, norm) are avaiable
           for use with a Rbf interpolator. See mystic.math.interpolate.Rbf
-          for more details.
+          for more details. if initialization produces a singlular matrix,
+          try non-zero smooth.
         """
         # basic configuration
         self.maxpts = kwds.pop('maxpts', None)  # N = 1000
@@ -142,7 +143,8 @@ class Interpolator(object):
         NOTE:
           additional keyword arguments (epsilon, smooth, norm) are avaiable
           for use with a Rbf interpolator. See mystic.math.interpolate.Rbf
-          for more details.
+          for more details. if initialization produces a singlular matrix,
+          try non-zero smooth.
         """
         import warnings
         from mystic.math.interpolate import interpf
@@ -177,7 +179,8 @@ class Interpolator(object):
         NOTE:
           additional keyword arguments (epsilon, smooth, norm) are avaiable
           for use with a Rbf interpolator. See mystic.math.interpolate.Rbf
-          for more details.
+          for more details. if initialization produces a singlular matrix,
+          try non-zero smooth.
         """
         maxpts = kwds.pop('maxpts', self.maxpts)
         noise = kwds.pop('noise', self.noise)
@@ -258,7 +261,8 @@ def interpolate(monitor, method=None, **kwds):
     NOTE:
       additional keyword arguments (epsilon, smooth, norm) are avaiable
       for use with a Rbf interpolator. See mystic.math.interpolate.Rbf
-      for more details.
+      for more details. if initialization produces a singlular matrix,
+      try non-zero smooth.
     '''
     d = Interpolator(monitor, method=method, **kwds)
     d.Interpolate()

--- a/examples3/ouq_models.py
+++ b/examples3/ouq_models.py
@@ -650,7 +650,8 @@ class InterpModel(OUQModel):
         cached: bool, if True, use a mystic.cache [default: False]
 
     NOTE:
-        any additional keyword arguments will be passed to the interpolator
+        any additional keyword arguments will be passed to the interpolator;
+        if a singular matrix is produced, try non-zero smooth or noise.
 
     NOTE:
         if cached is True, the default is to create a klepto.dir_archive
@@ -688,7 +689,8 @@ class InterpModel(OUQModel):
         cached: bool, if True, use a mystic.cache [default: False]
 
     NOTE:
-        any additional keyword arguments will be passed to the interpolator
+        any additional keyword arguments will be passed to the interpolator;
+        if a singular matrix is produced, try non-zero smooth or noise.
 
     NOTE:
         if data is a model, interpolator will use model's cached archive

--- a/mystic/math/_rbf.py
+++ b/mystic/math/_rbf.py
@@ -217,7 +217,8 @@ class Rbf(object):
             ximin = np.amin(self.xi, axis=1)
             edges = ximax-ximin
             edges = edges[np.nonzero(edges)]
-            self.epsilon = np.power(np.prod(edges)/self.N, 1.0/edges.size)
+            power = 1.0/edges.size if edges.size else np.inf
+            self.epsilon = np.power(np.prod(edges)/self.N, power)
         self.smooth = kwargs.pop('smooth', 0.0)
 
         self.function = kwargs.pop('function', 'multiquadric')
@@ -228,6 +229,8 @@ class Rbf(object):
         for item, value in kwargs.items():
             setattr(self, item, value)
 
+        # if self.A.size == 1 and self.A.flat[0] == 0. and smooth == 0.
+        #  produces singular matrix if function returns 0 at r == 0
         self.nodes = np.linalg.solve(self.A, self.di)
 
     @property

--- a/mystic/tests/test_interpolate.py
+++ b/mystic/tests/test_interpolate.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+#
+# Author: Mike McKerns (mmckerns @uqfoundation)
+# Copyright (c) 2024 The Uncertainty Quantification Foundation.
+# License: 3-clause BSD.  The full license text is available at:
+#  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
+"""
+test rbf interpolation
+"""
+
+import numpy as np
+x = np.random.rand(1,3)
+
+def cost(x):
+   return sum(np.sin(x)**2) + 1
+
+y = cost(x.T)
+
+import mystic.math.interpolate as ip
+
+# functions which are 1 at r = 0 reproduce a single datapoint
+fx = ip.Rbf(*np.vstack((x.T, y)), function='gaussian', smooth=0.0)
+assert (fx(*x.T) - y).sum() == 0.0
+fx = ip.Rbf(*np.vstack((x.T, y)), function='multiquadric', smooth=0.0)
+assert (fx(*x.T) - y).sum() == 0.0
+fx = ip.Rbf(*np.vstack((x.T, y)), function='inverse', smooth=0.0)
+assert (fx(*x.T) - y).sum() == 0.0
+
+# functions which are 0 at r = 0 are singular with a single datapoint
+fx = ip.Rbf(*np.vstack((x.T, y)), function='linear', smooth=-1e-100)
+assert fx(*x.T).sum() == 0.0
+fx = ip.Rbf(*np.vstack((x.T, y)), function='cubic', smooth=-1e-100)
+assert fx(*x.T).sum() == 0.0
+fx = ip.Rbf(*np.vstack((x.T, y)), function='quintic', smooth=-1e-100)
+assert fx(*x.T).sum() == 0.0
+fx = ip.Rbf(*np.vstack((x.T, y)), function='thin_plate', smooth=-1e-100)
+assert fx(*x.T).sum() == 0.0
+


### PR DESCRIPTION
## Summary
when interpolating with a single datapoint, epsilon should not throw a ZeroDivisionError.
then, the interpolations should succeed if:
- the interpolation function is non-zero at r=0
- the interpolation function is zero at r=0, and smooth is non-zero

Improves on #230 

## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Added relevant documentation that builds in sphinx without error.
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added a comment to issue #NNN, linking back to this PR.
- [x] Added rationale for any breakage of backwards compatibility.