### PR TITLE
fix constraints.unique after change to random.randrange

### DIFF
--- a/mystic/constraints.py
+++ b/mystic/constraints.py
@@ -995,7 +995,16 @@ Examples:
     return dec
 
 
-from random import randrange, shuffle
+from random import shuffle, Random
+# subclass to get '_randbelow_without_getrandbits' behavior for randrange
+class _Random(Random):
+    def _randbelow(self, n):
+        from random import random as _random
+        return n * _random()
+
+randrange = _Random().randrange
+del _Random, Random
+
 def unique(seq, full=None):
     """replace the duplicate values with unique values in 'full'
 
@@ -1038,16 +1047,16 @@ def unique(seq, full=None):
       ...     pass
       ...
     """
-    unique = set()
-    # replace all duplicates with 'None'
-    seq = [x if x not in unique and not unique.add(x) else None for x in seq]
-    lseq = len(seq)
     # check type if full not specified
     if full is None:
-        if all([isinstance(x, int) for x in unique]): full = int
+        if all([isinstance(x, int) for x in seq]): full = int
         else: full = float
         ok = True
     else: ok = False
+    # replace all duplicates with 'None'
+    unique = set()
+    seq = [x if x not in unique and not unique.add(x) else None for x in seq]
+    lseq = len(seq)
     # check all unique show up in 'full'
     if full in (int,float): # specified type, not range
         ok = ok or full==float or all([isinstance(x, int) for x in unique])

--- a/mystic/constraints.py
+++ b/mystic/constraints.py
@@ -1002,6 +1002,45 @@ class _Random(Random):
         from random import random as _random
         return n * _random()
 
+    def randrange(self, start, stop=None, step=1, _int=int):
+        """Choose a random item from range(start, stop[, step]).
+        """ #NOTE: from python3.8/random.py^
+        # doing adequate error checking.
+
+        istart = _int(start)
+        if istart != start:
+            raise ValueError("non-integer arg 1 for randrange()")
+        if stop is None:
+            if istart > 0:
+                return self._randbelow(istart)
+            raise ValueError("empty range for randrange()")
+
+        # stop argument supplied.
+        istop = _int(stop)
+        if istop != stop:
+            raise ValueError("non-integer stop for randrange()")
+        width = istop - istart
+        if step == 1 and width > 0:
+            return istart + self._randbelow(width)
+        if step == 1:
+            raise ValueError("empty range for randrange() (%d, %d, %d)" % (istart, istop, width))
+
+        # Non-unit step argument supplied.
+        istep = _int(step)
+        if istep != step:
+            raise ValueError("non-integer step for randrange()")
+        if istep > 0:
+            n = (width + istep - 1) // istep
+        elif istep < 0:
+            n = (width + istep + 1) // istep
+        else:
+            raise ValueError("zero step for randrange()")
+
+        if n <= 0:
+            raise ValueError("empty range for randrange()")
+
+        return istart + istep*self._randbelow(n)
+
 randrange = _Random().randrange
 del _Random, Random
 

--- a/mystic/tests/test_constraints.py
+++ b/mystic/tests/test_constraints.py
@@ -266,6 +266,68 @@ def test_sorting():
   assert monotonic(ascending=False, outer=True)(sum)(x) == sum(x)
 
 
+def test_unique():
+  x = [1, 2, 3, 1, 2, 10]
+  y = unique(x)
+  z = set(y).difference(x)
+  assert all(y.count(i) == 1 for i in y)
+  assert all(min(x) <= i < max(x) for i in z)
+  assert all(isinstance(i, int) for i in z)
+  y = unique(x, float)
+  z = set(y).difference(x)
+  assert all(y.count(i) == 1 for i in y)
+  assert all(min(x) <= i < max(x) for i in z)
+  assert all(isinstance(i, float) for i in z)
+  y = unique(x, range(11))
+  z = set(y).difference(x)
+  assert all(y.count(i) == 1 for i in y)
+  assert all(0 <= i < 11 for i in z)
+  assert all(isinstance(i, int) for i in z)
+  y = unique(x, {'min':0, 'max':11})
+  z = set(y).difference(x)
+  assert all(y.count(i) == 1 for i in y)
+  assert all(min(x) <= i < max(x) for i in z)
+  assert all(isinstance(i, float) for i in z)
+  y = unique(x, {'min':0, 'max':11, 'type':int})
+  z = set(y).difference(x)
+  assert all(y.count(i) == 1 for i in y)
+  assert all(min(x) <= i < max(x) for i in z)
+  assert all(isinstance(i, int) for i in z)
+  x = [1, 2, 3, 1.0, 2, 10]
+  y = unique(x, int)
+  z = set(y).difference(x)
+  assert all(y.count(i) == 1 for i in y)
+  assert all(min(x) <= i < max(x) for i in z)
+  assert all(isinstance(i, int) for i in z)
+  y = unique(x)
+  z = set(y).difference(x)
+  assert all(y.count(i) == 1 for i in y)
+  assert all(min(x) <= i < max(x) for i in z)
+  assert all(isinstance(i, float) for i in z)
+  x = [1, 2, 3, 1.5, 2, 10]
+  try:
+      unique(x, int)
+      assert False
+  except ValueError:
+      assert True
+  y = unique(x)
+  z = set(y).difference(x)
+  assert all(y.count(i) == 1 for i in y)
+  assert all(min(x) <= i < max(x) for i in z)
+  assert all(isinstance(i, float) for i in z)
+  x = [1, 2, 3, 1, 2, 13]
+  try:
+      unique(x, range(11))
+      assert False
+  except ValueError:
+      assert True
+  try:
+      unique([1,2,3,1,2,4], int)
+      assert False
+  except ValueError:
+      assert True
+
+
 if __name__ == '__main__':
   test_penalize()
   test_solve()
@@ -279,6 +341,7 @@ if __name__ == '__main__':
   test_with_constraint()
   test_discrete()
   test_sorting()
+  test_unique()
 
 
 # EOF


### PR DESCRIPTION
## Summary
changes to `random.randrange` causes failures to `constraints.unique` when a float is passed. Also, behavior has deviated from the examples in the code documentation.

```
>>> from mystic.constraints import unique
>>> unique([6.0, 7, 8, 9, 7, 8, 9])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mmckerns/lib/python3.8/site-packages/mystic/constraints.py", line 1084, in unique
    return [randrange(_min,_max,_int=float) if x is None else x for x in seq]
  File "/Users/mmckerns/lib/python3.8/site-packages/mystic/constraints.py", line 1084, in <listcomp>
    return [randrange(_min,_max,_int=float) if x is None else x for x in seq]
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/random.py", line 224, in randrange
    return istart + self._randbelow(width)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/random.py", line 254, in _randbelow_with_getrandbits
    k = n.bit_length()  # don't use (n-1) here because n can be 1
AttributeError: 'float' object has no attribute 'bit_length'
```

## Checklist

**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added rationale for any breakage of backwards compatibility.