### PR TITLE
index in sorting and monotonic constraint, extend sampled statistics 

### DIFF
--- a/mystic/math/discrete.py
+++ b/mystic/math/discrete.py
@@ -874,6 +874,27 @@ Notes:
     pts = self.sampled_support(npts)
     return _maximum_given_samples(f, pts, map)
 
+  def sampled_probneg(self, f, npts=10000, map=None):
+    """use sampling to calculate probability of negativity for a given function
+
+Args:
+    f (func): a function that takes a list and returns a number
+    npts (int, default=10000): the number of point masses sampled from the
+        underlying discrete measures
+    map (func, default=builtins.map): the mapping function
+
+Returns:
+    the probability that ``f < 0``, a float in ``[0.0,1.0]``
+
+Notes:
+    - the function ``f`` should take a list of ``positions`` (for example,
+      ``scenario.positions`` or ``product_measure.positions``) and return a
+      single value (e.g. 0.0)
+"""
+    from mystic.math.samples import _probneg_given_samples
+    pts = self.sampled_support(npts)
+    return _probneg_given_samples(f, pts, map)
+
   def sampled_pof(self, f, npts=10000, map=None):
     """use sampling to calculate probability of failure for a given function
 

--- a/mystic/math/samples.py
+++ b/mystic/math/samples.py
@@ -8,9 +8,9 @@
 """
 tools related to sampling
 """
-# These functions are consolidated and adapted from samples.py and cut.py in 
+# These functions are consolidated and adapted from samples.py and cut.py in
 # branches/UQ/math/ for general use.
-# sample() is from cut.py, and samplepts() is from examples2/seesaw2d.py, and 
+# sample() is from cut.py, and samplepts() is from examples2/seesaw2d.py, and
 # everything else is from samples.py
 
 # SAMPLING #
@@ -162,6 +162,66 @@ Inputs:
   return _pof_given_samples(f, pts, map)
 
 
+def sampled_ptp(f, lb, ub, npts=10000, map=None):
+  """
+use random sampling to calculate the spread of a function
+
+Inputs:
+    f -- a function that takes a list and returns a number
+    lb -- a list of lower bounds
+    ub -- a list of upper bounds
+    npts -- the number of points to sample [Default is npts=10000]
+    map -- the mapping function [Default is builtins.map]
+"""
+  pts = _random_samples(lb, ub, npts)
+  return _ptp_given_samples(f, pts, map)
+
+
+def sampled_probneg(f, lb, ub, npts=10000, map=None):
+  """
+use random sampling to calculate probability of negativity for a function
+
+Inputs:
+    f -- a function that takes a list and returns a number
+    lb -- a list of lower bounds
+    ub -- a list of upper bounds
+    npts -- the number of points to sample [Default is npts=10000]
+    map -- the mapping function [Default is builtins.map]
+"""
+  pts = _random_samples(lb, ub, npts)
+  return _probneg_given_samples(f, pts, map)
+
+
+def sampled_minimum(f, lb, ub, npts=10000, map=None):
+  """
+use random sampling to calculate the minimum of a function
+
+Inputs:
+    f -- a function that takes a list and returns a number
+    lb -- a list of lower bounds
+    ub -- a list of upper bounds
+    npts -- the number of points to sample [Default is npts=10000]
+    map -- the mapping function [Default is builtins.map]
+"""
+  pts = _random_samples(lb, ub, npts)
+  return _minimum_given_samples(f, pts, map)
+
+
+def sampled_maximum(f, lb, ub, npts=10000, map=None):
+  """
+use random sampling to calculate the maximum of a function
+
+Inputs:
+    f -- a function that takes a list and returns a number
+    lb -- a list of lower bounds
+    ub -- a list of upper bounds
+    npts -- the number of points to sample [Default is npts=10000]
+    map -- the mapping function [Default is builtins.map]
+"""
+  pts = _random_samples(lb, ub, npts)
+  return _maximum_given_samples(f, pts, map)
+
+
 # ALTERNATE: GIVEN SAMPLE POINTS #
 def _pof_given_samples(f, pts, map=None):
   """
@@ -253,6 +313,41 @@ Inputs:
     from builtins import map
   from numpy import transpose, ptp, atleast_2d
   return ptp(list(map(f, atleast_2d(transpose(pts)).tolist())))
+
+
+def _probneg_given_samples(f, pts, map=None):
+  """
+use given sample pts to calculate probability of negativity for function f
+
+Inputs:
+    f -- a function that returns a single value, given a list of inputs
+    pts -- a list of sample points
+    map -- the mapping function [Default is builtins.map]
+"""
+  if map is None:
+    from builtins import map
+  from numpy import transpose, clip, count_nonzero, atleast_2d
+  results = list(map(f, atleast_2d(transpose(pts)).tolist()))
+  results = clip(results, None, 0) # negative-only
+  pneg = float(count_nonzero(results)) / float(results.size)
+  return pneg
+
+
+def _negativity_given_samples(f, pts, map=None):
+  """
+use given sample pts to calculate negativity of function f
+
+Inputs:
+    f -- a function that returns a single value, given a list of inputs
+    pts -- a list of sample points
+    map -- the mapping function [Default is builtins.map]
+"""
+  if map is None:
+    from builtins import map
+  from numpy import transpose, clip, atleast_2d
+  results = list(map(f, atleast_2d(transpose(pts)).tolist()))
+  neg = -clip(results, None, 0).sum() or 0.0
+  return neg
 
 
 def sampled_pts(pts, lb, ub, map=None):

--- a/mystic/tests/test_constraints.py
+++ b/mystic/tests/test_constraints.py
@@ -259,6 +259,11 @@ def test_sorting():
   assert monotonic()(negative)(x) == monotonic(ascending=False, outer=True)(negative)(x)
   assert monotonic(outer=True)(negative)(x) == monotonic(ascending=False)(negative)(x)
 
+  assert sorting(index=0)(negative)(x) == sorting(index=[0])(negative)(x)
+  assert sorting(index=(0,1,2))(negative)(x) == sorting(index=(-4,-5,2))(negative)(x)
+  assert monotonic(index=0)(negative)(x) == monotonic(index=[0])(negative)(x)
+  assert monotonic(index=(0,1,2))(negative)(x) == monotonic(index=(-4,-5,2))(negative)(x)
+
   from numpy import maximum as max, minimum as min
   assert monotonic()(sum)(x) == sum(max.accumulate(x))
   assert monotonic(outer=True)(sum)(x) == sum(x)

--- a/mystic/tests/test_samples.py
+++ b/mystic/tests/test_samples.py
@@ -6,8 +6,8 @@
 #  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
 
 try:
-  import multiprocess as mp
-  p = mp.Pool()
+  from pathos.pools import ProcessPool
+  p = ProcessPool()
   pmap = p.map
 except ImportError:
   pmap = None
@@ -21,6 +21,7 @@ def inside(x):
   return mm.sphere(x) < 1
 lb,ub = [0,0,0],[1,1,1]
 kwd = dict(tol=None, rel=.05)
+_kwd = dict(tol=.05, rel=None)
 
 # lb,ub must be iterable
 miss,hits = ms.sample(inside, lb, ub)
@@ -45,6 +46,31 @@ assert my.math.approx_equal(mi.integrated_variance(mm.sphere, lb, ub), ans, **kw
 assert my.math.approx_equal(ms.sampled_variance(mm.sphere, lb[:1], ub[:1]) * 3, ans, **kwd)
 if pmap:
   a = ms.sampled_variance(mm.sphere, lb, ub, map=pmap)
+  assert my.math.approx_equal(a, ans, **kwd)
+
+ans = ms.sampled_minimum(mm.sphere, lb, ub, npts=50000)
+assert my.math.approx_equal(mm.sphere(my.solvers.fmin(mm.sphere, x0=[.5,.5,.5], bounds=list(zip(lb, ub)), disp=False)), ans, **_kwd)
+assert my.math.approx_equal(ms.sampled_minimum(mm.sphere, lb[:1], ub[:1]) * 3, ans, **_kwd)
+if pmap:
+  a = ms.sampled_minimum(mm.sphere, lb, ub, npts=50000, map=pmap)
+  assert my.math.approx_equal(a, ans, **_kwd)
+
+ans = ms.sampled_maximum(mm.sphere, lb[:2], ub[:2], npts=50000)
+assert my.math.approx_equal(ms.sampled_maximum(mm.sphere, lb[:1], ub[:1]) * 2, ans, **_kwd)
+if pmap:
+  a = ms.sampled_maximum(mm.sphere, lb[:2], ub[:2], npts=50000, map=pmap)
+  assert my.math.approx_equal(a, ans, **_kwd)
+
+ans = ms.sampled_ptp(mm.sphere, lb[:2], ub[:2], npts=50000)
+assert my.math.approx_equal(ms.sampled_ptp(mm.sphere, lb[:1], ub[:1]) * 2, ans, **_kwd)
+if pmap:
+  a = ms.sampled_ptp(mm.sphere, lb[:2], ub[:2], npts=50000, map=pmap)
+  assert my.math.approx_equal(a, ans, **_kwd)
+
+ans = ms.sampled_probneg(mm.sphere, lb, ub)
+assert my.math.approx_equal(ms.sampled_probneg(mm.sphere, lb[:1], ub[:1]), ans, **kwd)
+if pmap:
+  a = ms.sampled_probneg(mm.sphere, lb, ub, map=pmap)
   assert my.math.approx_equal(a, ans, **kwd)
 
 ans = ms.sampled_pof(inside, lb, ub)


### PR DESCRIPTION
## Summary
enable sorting and monotonic in mystic.constraints to take an index; add a sampled ptp, min, max, and probability of negativity to mystic.math.samples 

## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Added relevant documentation that builds in sphinx without error.
- [x] Added new features that are documented with examples.
- [x] Artifacts produced with the main branch work as expected under this PR.