### PR TITLE
sort probabilities of Dirac masses, and use while not terminated in optML

### DIFF
--- a/examples3/misc6.py
+++ b/examples3/misc6.py
@@ -32,7 +32,7 @@ kwds = dict(npts=500, ipts=None, itol=1e-8, iter=5)
 
 from mystic.math.discrete import product_measure
 from mystic.math import almostEqual as almost
-from mystic.constraints import and_, integers
+from mystic.constraints import and_, integers, sorting
 from mystic.coupler import outer, additive
 from emulators import cost6, x6, bounds6, error6, wR
 from mystic import suppressed
@@ -44,6 +44,8 @@ wub = (1,1,1,1,1,1)
 # number of Dirac masses to use for each parameter
 npts = (2,2,2,2,2,2) #NOTE: rv = (w0,w0,x0,x0,w1,w1,x1,x1,w2,w2,x2,x2,w3,w3,x3,x3,w4,w4,x4,x4,w5,w5,x5,x5)
 index = (2,3,6,7,10,11,14,15,18,19,22,23)  #NOTE: rv[index] -> x0,x0,x1,x1,x2,x2,x3,x3,x4,x4,x5,x5
+ordered = lambda constraint: sorting(index=(0,1))(sorting(index=(4,5))(sorting(index=(8,9))(sorting(index=(12,13))(sorting(index=(16,17))(sorting(index=(20,21))(constraint))))))
+
 # moments and uncertainty in first parameter
 a_ave = x6[0]
 a_var = .5 * error6[0]**2
@@ -89,6 +91,17 @@ def flatten(npts):
             c = product_measure().load(rv, npts)
             c = f(c)
             return c.flatten()
+        return func
+    return dec
+
+
+def unflatten(npts):
+    'convert a "flattened" constraint to a moment constraint'
+    def dec(f):
+        def func(c):
+            rv = c.flatten()
+            rv = f(rv)
+            return product_measure().load(rv, npts)
         return func
     return dec
 
@@ -190,10 +203,10 @@ is_cons = lambda c: bool(additive(is_con5)(additive(is_con4)(additive(is_con3)(a
 
 ## position-based constraints ##
 # impose constraints sequentially (faster, but assumes are decoupled)
-scons = flatten(npts)(outer(momcon5)(outer(momcon4)(outer(momcon3)(outer(momcon2)(outer(momcon1)(outer(momcon0)(normcon)))))))
+scons = flatten(npts)(outer(momcon5)(outer(momcon4)(outer(momcon3)(outer(momcon2)(outer(momcon1)(outer(momcon0)(unflatten(npts)(ordered(flatten(npts)(normcon))))))))))
 
 # impose constraints concurrently (slower, but safer)
-ccons = and_(flatten(npts)(normcon), flatten(npts)(momcon0), flatten(npts)(momcon1), flatten(npts)(momcon2), flatten(npts)(momcon3), flatten(npts)(momcon4), flatten(npts)(momcon5))
+ccons = and_(ordered(flatten(npts)(normcon)), flatten(npts)(momcon0), flatten(npts)(momcon1), flatten(npts)(momcon2), flatten(npts)(momcon3), flatten(npts)(momcon4), flatten(npts)(momcon5))
 
 # check parameters (instead of measures)
 iscon = check(npts)(is_cons)

--- a/examples3/xrd_optML3.py
+++ b/examples3/xrd_optML3.py
@@ -11,6 +11,7 @@ optimization of 3-input cost function using online learning of a surrogate
 """
 import os
 from mystic.solvers import diffev2
+from mystic.monitors import LoggingMonitor
 from mystic.math.legacydata import datapoint
 from mystic.cache.archive import file_archive, read as get_db
 from ouq_models import WrapModel, InterpModel
@@ -41,8 +42,14 @@ surrogate = InterpModel("surrogate", nx=3, ny=None, data=truth, smooth=0.0,
                         noise=0.0, method="thin_plate", extrap=False)
 
 # iterate until error (of candidate minimum) < 1e-3
-error = float("inf")
-while error > 1e-3:
+tracker = LoggingMonitor(1, filename='error.txt', label='error')
+from mystic.abstract_solver import AbstractSolver
+from mystic.termination import VTR
+loop = AbstractSolver(3) # nx
+loop.SetTermination(VTR(1e-3)) #XXX: VTRCOG, TimeLimits, etc?
+loop.SetEvaluationLimits(maxiter=500)
+loop.SetGenerationMonitor(tracker)
+while not loop.Terminated():
 
     # fit the surrogate to data in truth database
     surrogate.fit(data=data)
@@ -62,12 +69,21 @@ while error > 1e-3:
     print("candidate: %s; error: %s" % (ysur, error))
     print("evaluations of truth: %s" % len(data))
 
+    # save to tracker if less than current best
+    if len(tracker) and tracker.y[-1] < error:
+        tracker(*tracker[-1])
+    else: tracker(xnew, error)
+
     # add most recent candidate minimum evaluated with truth to database
     pt = datapoint(xnew, value=ynew)
     data.append(pt)
 
+# get the results at the best parameters from the truth database
+xbest = tracker[-1][0]
+ybest = archive[tuple(xbest)]
+
 # print the best parameters
-print(f"Best solution is {xnew} with beta {ynew}")
+print(f"Best solution is {xbest} with beta {ybest}")
 print(f"Reference solution: {target}")
-ratios = [x / y for x, y in zip(target, xnew)]
+ratios = [x / y for x, y in zip(target, xbest)]
 print(f"Ratios of best to reference solution: {ratios}")

--- a/examples3/xrd_optML3DT.py
+++ b/examples3/xrd_optML3DT.py
@@ -11,6 +11,7 @@ optimization of 3-input cost function using online learning of a surrogate
 """
 import os
 from mystic.solvers import diffev2
+from mystic.monitors import LoggingMonitor
 from mystic.math.legacydata import datapoint
 from mystic.cache.archive import file_archive, read as get_db
 from ouq_models import WrapModel, LearnedModel
@@ -56,8 +57,14 @@ mlkw = dict(estimator=best.estimator, transform=best.transform)
 surrogate = LearnedModel('surrogate', nx=3, ny=None, data=truth, **mlkw)
 
 # iterate until error (of candidate minimum) < 1e-3
-error = float("inf")
-while error > 1e-3:
+tracker = LoggingMonitor(1, filename='error.txt', label='error')
+from mystic.abstract_solver import AbstractSolver
+from mystic.termination import VTR
+loop = AbstractSolver(3) # nx
+loop.SetTermination(VTR(1e-3)) #XXX: VTRCOG, TimeLimits, etc?
+loop.SetEvaluationLimits(maxiter=500)
+loop.SetGenerationMonitor(tracker)
+while not loop.Terminated():
 
     # fit the surrogate to data in truth database
     surrogate.fit(data=data)
@@ -77,12 +84,21 @@ while error > 1e-3:
     print("candidate: %s; error: %s" % (ysur, error))
     print("evaluations of truth: %s" % len(data))
 
+    # save to tracker if less than current best
+    if len(tracker) and tracker.y[-1] < error:
+        tracker(*tracker[-1])
+    else: tracker(xnew, error)
+
     # add most recent candidate minimum evaluated with truth to database
     pt = datapoint(xnew, value=ynew)
     data.append(pt)
 
+# get the results at the best parameters from the truth database
+xbest = tracker[-1][0]
+ybest = archive[tuple(xbest)]
+
 # print the best parameters
-print(f"Best solution is {xnew} with beta {ynew}")
+print(f"Best solution is {xbest} with beta {ybest}")
 print(f"Reference solution: {target}")
-ratios = [x / y for x, y in zip(target, xnew)]
+ratios = [x / y for x, y in zip(target, xbest)]
 print(f"Ratios of best to reference solution: {ratios}")

--- a/examples3/xrd_optML3NN.py
+++ b/examples3/xrd_optML3NN.py
@@ -11,6 +11,7 @@ optimization of 3-input cost function using online learning of a surrogate
 """
 import os
 from mystic.solvers import diffev2
+from mystic.monitors import LoggingMonitor
 from mystic.math.legacydata import datapoint
 from mystic.cache.archive import file_archive, read as get_db
 from ouq_models import WrapModel, LearnedModel
@@ -49,8 +50,14 @@ mlkw = dict(estimator=best.estimator, transform=best.transform)
 surrogate = LearnedModel('surrogate', nx=3, ny=None, data=truth, **mlkw)
 
 # iterate until error (of candidate minimum) < 1e-3
-error = float("inf")
-while error > 1e-3:
+tracker = LoggingMonitor(1, filename='error.txt', label='error')
+from mystic.abstract_solver import AbstractSolver
+from mystic.termination import VTR
+loop = AbstractSolver(3) # nx
+loop.SetTermination(VTR(1e-3)) #XXX: VTRCOG, TimeLimits, etc?
+loop.SetEvaluationLimits(maxiter=500)
+loop.SetGenerationMonitor(tracker)
+while not loop.Terminated():
 
     # fit the surrogate to data in truth database
     surrogate.fit(data=data)
@@ -70,12 +77,21 @@ while error > 1e-3:
     print("candidate: %s; error: %s" % (ysur, error))
     print("evaluations of truth: %s" % len(data))
 
+    # save to tracker if less than current best
+    if len(tracker) and tracker.y[-1] < error:
+        tracker(*tracker[-1])
+    else: tracker(xnew, error)
+
     # add most recent candidate minimum evaluated with truth to database
     pt = datapoint(xnew, value=ynew)
     data.append(pt)
 
+# get the results at the best parameters from the truth database
+xbest = tracker[-1][0]
+ybest = archive[tuple(xbest)]
+
 # print the best parameters
-print(f"Best solution is {xnew} with beta {ynew}")
+print(f"Best solution is {xbest} with beta {ybest}")
 print(f"Reference solution: {target}")
-ratios = [x / y for x, y in zip(target, xnew)]
+ratios = [x / y for x, y in zip(target, xbest)]
 print(f"Ratios of best to reference solution: {ratios}")

--- a/examples3/xrd_optML4.py
+++ b/examples3/xrd_optML4.py
@@ -45,8 +45,13 @@ surrogate = InterpModel("surrogate", nx=4, ny=None, data=truth, smooth=0.0,
 import mystic._counter as it
 counter = it.Counter()
 tracker = LoggingMonitor(1, filename='error.txt', label='error')
-error = float("inf")
-while error > 1e-3:
+from mystic.abstract_solver import AbstractSolver
+from mystic.termination import VTR
+loop = AbstractSolver(4) # nx
+loop.SetTermination(VTR(1e-3)) #XXX: VTRCOG, TimeLimits, etc?
+loop.SetEvaluationLimits(maxiter=500)
+loop.SetGenerationMonitor(tracker)
+while not loop.Terminated():
 
     # fit the surrogate to data in truth database
     surrogate.fit(data=data)
@@ -67,14 +72,22 @@ while error > 1e-3:
     print("truth: %s @ %s" % (ynew, xnew))
     print("candidate: %s; error: %s" % (ysur, error))
     print("evaluations of truth: %s" % len(data))
-    tracker(xnew, error)
+
+    # save to tracker if less than current best
+    if len(tracker) and tracker.y[-1] < error:
+        tracker(*tracker[-1])
+    else: tracker(xnew, error)
 
     # add most recent candidate minimum evaluated with truth to database
     pt = datapoint(xnew, value=ynew)
     data.append(pt)
 
+# get the results at the best parameters from the truth database
+xbest = tracker[-1][0]
+ybest = archive[tuple(xbest)]
+    
 # print the best parameters
-print(f"Best solution is {xnew} with Rwp {ynew}")
+print(f"Best solution is {xbest} with Rwp {ybest}")
 print(f"Reference solution: {target}")
-ratios = [x / y for x, y in zip(target, xnew)]
+ratios = [x / y for x, y in zip(target, xbest)]
 print(f"Ratios of best to reference solution: {ratios}")

--- a/examples3/xrd_optML4v.py
+++ b/examples3/xrd_optML4v.py
@@ -45,13 +45,17 @@ surrogate = InterpModel("surrogate", nx=4, ny=None, data=truth, smooth=0.0,
 
 # iterate until error (of candidate minimum) < 1e-3
 N = 4
+import numpy as np
 import mystic._counter as it
 counter = it.Counter()
 tracker = LoggingMonitor(1, filename='error.txt', label='error')
-import numpy as np
-error = np.array([float('inf')]); idx = 0
-#while error[:N].mean() > 1e-3:
-while error[idx] > 1e-3:
+from mystic.abstract_solver import AbstractSolver
+from mystic.termination import VTR
+loop = AbstractSolver(4) # nx
+loop.SetTermination(VTR(1e-3)) #XXX: VTRCOG, TimeLimits, etc?
+loop.SetEvaluationLimits(maxiter=500)
+loop.SetGenerationMonitor(tracker)
+while not loop.Terminated():
 
     # fit the surrogate to data in truth database
     surrogate.fit(data=data)
@@ -76,17 +80,22 @@ while error[idx] > 1e-3:
     print("candidate: %s; error: %s" % (ysurr[idx], error[idx]))
     print("error ave: %s; error max: %s" % (error.mean(), error.max()))
     print("evaluations of truth: %s" % len(data))
-    tracker(xdata[idx], error[idx])
+
+    # save to tracker if less than current best
+    if len(tracker) and tracker.y[-1] < error[idx]:
+        tracker(*tracker[-1])
+    else: tracker(xdata[idx], error[idx])
 
     # add most recent candidate extrema to truth database
     data.load(xdata, ytrue)
 
-# get minimum of last batch of results
-xnew = xdata[idx]
-ynew = ytrue[idx]
+# get the results at the best parameters from the truth database
+xbest = tracker[-1][0]
+#ybest = archive[tuple(xbest)]
+ybest = data[data.coords.index(xbest)].value
 
 # print the best parameters
-print(f"Best solution is {xnew} with Rwp {ynew}")
+print(f"Best solution is {xbest} with Rwp {ybest}")
 print(f"Reference solution: {target}")
-ratios = [x / y for x, y in zip(target, xnew)]
+ratios = [x / y for x, y in zip(target, xbest)]
 print(f"Ratios of best to reference solution: {ratios}")

--- a/examples3/xrd_optML4xs.py
+++ b/examples3/xrd_optML4xs.py
@@ -11,6 +11,7 @@ optimization of 4-input cost function using online learning of a surrogate
 """
 import os
 from mystic.samplers import LatticeSampler
+from mystic.monitors import LoggingMonitor
 from ouq_models import WrapModel, InterpModel
 from emulators import cost4 as cost, x4 as target, bounds4 as bounds
 from mystic.cache.archive import file_archive, read as get_db
@@ -48,9 +49,14 @@ surrogate = InterpModel("surrogate", nx=4, ny=None, data=truth, smooth=0.0,
 # iterate until error (of candidate minimum) < 1e-3
 N = 4
 import numpy as np
-error = np.array([float('inf')]); idx = 0
-#while error[:N].mean() > 1e-3:
-while error[idx] > 1e-3:
+tracker = LoggingMonitor(1, filename='error.txt', label='error')
+from mystic.abstract_solver import AbstractSolver
+from mystic.termination import VTR
+loop = AbstractSolver(4) # nx
+loop.SetTermination(VTR(1e-3)) #XXX: VTRCOG, TimeLimits, etc?
+loop.SetEvaluationLimits(maxiter=500)
+loop.SetGenerationMonitor(tracker)
+while not loop.Terminated():
 
     # fit a new surrogate to data in truth database
     get_db('surrogate').clear()
@@ -71,15 +77,21 @@ while error[idx] > 1e-3:
     print("ave mins: %s; at min: %s" % (error[:N].mean(), error[idx]))
     print("evaluations of truth: %s" % len(data))
 
+    # save to tracker if less than current best
+    if len(tracker) and tracker.y[-1] < error[idx]:
+        tracker(*tracker[-1])
+    else: tracker(surr.coords[idx], error[idx])
+
     # add most recent candidate extrema to truth database
     data.load(surr.coords, ytrue)
 
-# get minimum of last batch of results
-xnew = surr.coords[idx]
-ynew = ytrue[idx]
+# get the results at the best parameters from the truth database
+xbest = tracker[-1][0]
+#ybest = archive[tuple(xbest)]
+ybest = data[data.coords.index(xbest)].value
 
 # print the best parameters
-print(f"Best solution is {xnew} with Rwp {ynew}")
+print(f"Best solution is {xbest} with Rwp {ybest}")
 print(f"Reference solution: {target}")
-ratios = [x / y for x, y in zip(target, xnew)]
+ratios = [x / y for x, y in zip(target, xbest)]
 print(f"Ratios of best to reference solution: {ratios}")


### PR DESCRIPTION
## Summary
as the order of Dirac masses is arbitrary, create some stability by sorting the masses by their probability -- this should help convergence, and as a bonus will make the convergence plots looks better

improve convergence of the while loop in the optML examples by using solver termination conditions (by leveraging an abstract solver)

## Checklist
**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Added relevant documentation that builds in sphinx without error.
- [ ] Added new features that are documented with examples.
- [x] Artifacts produced with the main branch work as expected under this PR.