### PR TITLE
add Variance and Negativity to examples3, samples, and measures

### DIFF
--- a/examples3/emulators_.py
+++ b/examples3/emulators_.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# 
+# Author: Mike McKerns (mmckerns @uqfoundation)
+# Copyright (c) 2024 The Uncertainty Quantification Foundation.
+# License: 3-clause BSD.  The full license text is available at:
+#  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
+'''
+noisy emulator:
+* input parameters (a_alpha, c_alpha, a_steel)
+  with solved values at:
+    [2.9306538, 4.6817646, 3.6026807]
+  measured error of:
+    [1e-4, 1e-4, 1e-4]
+  bounds at:
+    [(0.95 * i, 1.05 * i) for i in solved]
+  yielding a minimum at:
+    a_beta = 3.233392
+  with a measured error of:
+    a_beta_error = 1e-4
+  and gaussian noise on the input parameters of:
+    sigma = 0.001
+'''
+from itertools import repeat
+from mystic.monitors import LoggingMonitor
+from emulators import cost3, x3, bounds3
+from noisy import noisy
+
+try: # parallel maps
+    from pathos.maps import Map
+    from pathos.pools import ProcessPool, ThreadPool, SerialPool
+    cmap = Map(SerialPool) #ProcessPool
+except ImportError:
+    cmap = map
+
+# use a logging monitor to track cost function evaluations
+monitor3 = LoggingMonitor(1, filename='truth.txt', label='truth')
+
+# generate an objective with gaussian noise on the inputs
+noisycost3 = lambda x: cost3(noisy(x, sigma=.001))
+
+# generate a tracked cost function
+def trackcost3(x):
+  fx = noisycost3(x)
+  monitor3(x, fx)
+  return fx
+
+# average the cost over the number of cost evaluations per objective call
+avecost3 = lambda x, n=1: sum(cmap(trackcost3, repeat(x, n)))/n
+
+# set the number of cost evaluations per objective call
+ave10cost3 = lambda x: avecost3(x, n=10)

--- a/examples3/xrd_design3_.py
+++ b/examples3/xrd_design3_.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+#
+# Author: Mike McKerns (mmckerns @caltech and @uqfoundation)
+# Copyright (c) 2022-2024 The Uncertainty Quantification Foundation.
+# License: 3-clause BSD.  The full license text is available at:
+#  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
+"""
+We estimate the error on the lattice parameters as σ ~ 1e-4, as if N(μ,σ^2).
+
+Given uncertainty in the selected lattice parameters, find the:
+1) expected variance of "beta"
+2) upper/lower bound on the expected variance of "beta"
+3) expected VAR of "beta"
+4) upper/lower bound on the expected VAR of "beta"
+5) expected negativity of "beta"
+6) upper/lower bound on the expected negativity of "beta"
+
+lattice parameters x3 = (a_alpha, c_alpha, a_steel) +/- error3 in bounds3,
+where: x3 = [2.9306538, 4.6817646, 3.6026807] (potentially μ)
+       error3 = [1e-4, 1e-4, 1e-4] (potentially σ)
+       bounds3 = [(0.95 * i, 1.05 * i) for i in x3]
+looking for impact on a_beta, we could also impose a_beta +/- error,
+where: a_beta = [3.233392] (potentially μ)
+       error = [1e-4] (potentially σ)
+"""
+
+if __name__ == '__main__':
+
+    from misc3 import *
+    from ouq import Variance, ValueAtRisk
+    from ouq_ import Negativity
+
+    try: # parallel maps
+        from pathos.maps import Map
+        from pathos.pools import ProcessPool, ThreadPool, _ThreadPool
+        pmap = Map(ProcessPool) if Ns else Map() # for sampling
+        param['map'] = Map()#Map(ThreadPool) # for objective
+        if ny: param['axmap'] = Map(_ThreadPool, join=True) # for multi-axis
+        smap = Map(_ThreadPool, join=True) if ny else Map() # for expected value
+    except ImportError:
+        pmap = smap = None
+
+    import datetime
+    kwds.update(dict(smap=smap, verbose=False))
+    axis = None
+
+    # where x,F(x) has uncertainty, calculate:
+    # expected variance
+    print('\n%s'% datetime.datetime.now())
+    param['id'] = 0 #NOTE: to distinguish solver in multi-run logging
+    b = Variance(model, bnd, constraint=ccons, cvalid=is_cons, samples=Ns, map=pmap)
+    b.expected(archive='ave.db', axis=axis, **kwds, **param)
+    print("expected variance per axis:")
+    for ax,solver in b._expect.items():
+        print("%s: %s @ %s" % (ax, solver.bestEnergy, solver.bestSolution))
+
+    # lower bound on variance
+    if param['id'] is not None: param['id'] += 1
+    print('\n%s'% datetime.datetime.now())
+    b.lower_bound(axis=axis, **param)
+    print("lower bound on expected variance per axis:")
+    for ax,solver in b._lower.items():
+        print("%s: %s @ %s" % (ax, solver.bestEnergy, solver.bestSolution))
+
+    # calculate upper bound on variance
+    if param['id'] is not None: param['id'] += 1
+    print('\n%s'% datetime.datetime.now())
+    b.upper_bound(axis=axis, **param)
+    print("upper bound on expected variance per axis:")
+    for ax,solver in b._upper.items():
+        print("%s: %s @ %s" % (ax, -solver.bestEnergy, solver.bestSolution))
+
+    # expected VAR of value
+    if param['id'] is not None: param['id'] += 1
+    print('\n%s'% datetime.datetime.now())
+    b = ValueAtRisk(model, bnd, constraint=ccons, cvalid=is_cons, samples=Ns, map=pmap)
+    b.expected(archive='min.db', axis=axis, **kwds, **param)
+    print("expected VAR per axis:")
+    for ax,solver in b._expect.items():
+        print("%s: %s @ %s" % (ax, solver.bestEnergy, solver.bestSolution))
+
+    # lower bound on VAR
+    if param['id'] is not None: param['id'] += 1
+    print('\n%s'% datetime.datetime.now())
+    b.lower_bound(axis=axis, **param)
+    print("lower bound on expected VAR per axis:")
+    for ax,solver in b._lower.items():
+        print("%s: %s @ %s" % (ax, solver.bestEnergy, solver.bestSolution))
+
+    # upper bound on VAR
+    if param['id'] is not None: param['id'] += 1
+    print('\n%s'% datetime.datetime.now())
+    b.upper_bound(axis=axis, **param)
+    print("upper bound on expected VAR per axis:")
+    for ax,solver in b._upper.items():
+        print("%s: %s @ %s" % (ax, -solver.bestEnergy, solver.bestSolution))
+
+    # expected negativity of value
+    if param['id'] is not None: param['id'] += 1
+    print('\n%s'% datetime.datetime.now())
+    b = Negativity(model, bnd, constraint=ccons, cvalid=is_cons, samples=Ns, map=pmap)
+    b.expected(archive='max.db', axis=axis, **kwds, **param)
+    print("expected negativity per axis:")
+    for ax,solver in b._expect.items():
+        print("%s: %s @ %s" % (ax, solver.bestEnergy, solver.bestSolution))
+
+    # lower bound on negativity
+    if param['id'] is not None: param['id'] += 1
+    print('\n%s'% datetime.datetime.now())
+    b.lower_bound(axis=axis, **param)
+    print("lower bound on expected negativity per axis:")
+    for ax,solver in b._lower.items():
+        print("%s: %s @ %s" % (ax, solver.bestEnergy, solver.bestSolution))
+
+    # upper bound on negativity
+    if param['id'] is not None: param['id'] += 1
+    print('\n%s'% datetime.datetime.now())
+    b.upper_bound(axis=axis, **param)
+    print("upper bound on expected negativity per axis:")
+    for ax,solver in b._upper.items():
+        print("%s: %s @ %s" % (ax, -solver.bestEnergy, solver.bestSolution))
+
+    # shutdown
+    print('\n%s'% datetime.datetime.now())
+    if pmap is not None:
+        pmap.close(); pmap.join(); pmap.clear()
+    pmap = param['map']
+    if pmap is not None:
+        pmap.close(); pmap.join(); pmap.clear()
+    if ny:
+        pmap = param['axmap']
+        if pmap is not None:
+            pmap.close(); pmap.join(); pmap.clear()
+    if smap is not None:
+        smap.close(); smap.join(); smap.clear()

--- a/examples3/xrd_optML3n.py
+++ b/examples3/xrd_optML3n.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+#
+# Author: Mike McKerns (mmckerns @caltech and @uqfoundation)
+# Copyright (c) 2022-2024 The Uncertainty Quantification Foundation.
+# License: 3-clause BSD.  The full license text is available at:
+#  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
+#
+# adapted from XRD example at: https://spotlight.readthedocs.io/
+"""
+optimization of 3-input cost function using online learning of a surrogate
+"""
+import os
+from mystic.solvers import diffev2
+from mystic.monitors import LoggingMonitor
+from mystic.math.legacydata import datapoint
+from mystic.cache.archive import file_archive, read as get_db
+from ouq_models import WrapModel, InterpModel
+from emulators_ import ave10cost3 as cost, x3 as target, bounds3 as bounds
+
+# remove any prior cached evaluations of truth (i.e. an 'expensive' model)
+if os.path.exists("truth.db"):
+    os.remove("truth.db")
+
+try: # parallel maps
+    from pathos.maps import Map
+    from pathos.pools import ProcessPool, ThreadPool, SerialPool
+    pmap = Map(SerialPool) #ProcessPool
+except ImportError:
+    pmap = None
+
+# generate a dataset by sampling truth
+archive = get_db('truth.db', type=file_archive)
+truth = WrapModel("truth", cost, nx=3, ny=None, cached=archive)
+data = truth.sample(bounds, pts=[2, 1, 1], map=pmap)
+
+# shutdown mapper
+if pmap is not None:
+    pmap.close(); pmap.join(); pmap.clear()
+
+# create an inexpensive surrogate for truth
+surrogate = InterpModel("surrogate", nx=3, ny=None, data=truth, smooth=0.0,
+                        noise=0.0, method="thin_plate", extrap=False)
+
+# iterate until error (of candidate minimum) < 1e-3
+tracker = LoggingMonitor(1, filename='error.txt', label='error')
+from mystic.abstract_solver import AbstractSolver
+from mystic.termination import VTR
+loop = AbstractSolver(3) # nx
+loop.SetTermination(VTR(1e-3)) #XXX: VTRCOG, TimeLimits, etc?
+loop.SetEvaluationLimits(maxiter=500)
+loop.SetGenerationMonitor(tracker)
+while not loop.Terminated():
+
+    # fit the surrogate to data in truth database
+    surrogate.fit(data=data)
+
+    # find the minimum of the surrogate
+    results = diffev2(lambda x: surrogate(x), bounds, npop=20,
+                      bounds=bounds, gtol=500, full_output=True)
+
+    # evaluate truth at the same input as the surrogate minimum
+    xnew = results[0].tolist()
+    ynew = truth(xnew)
+
+    # compute absolute error between truth and surrogate at candidate minimum
+    ysur = results[1]
+    error = abs(ynew - ysur)
+    print("truth: %s @ %s" % (ynew, xnew))
+    print("candidate: %s; error: %s" % (ysur, error))
+    print("evaluations of truth: %s" % len(data))
+
+    # save to tracker if less than current best
+    if len(tracker) and tracker.y[-1] < error:
+        tracker(*tracker[-1])
+    else: tracker(xnew, error)
+
+    # add most recent candidate minimum evaluated with truth to database
+    pt = datapoint(xnew, value=ynew)
+    data.append(pt)
+
+# get the results at the best parameters from the truth database
+xbest = tracker[-1][0]
+ybest = archive[tuple(xbest)]
+
+# print the best parameters
+print(f"Best solution is {xbest} with beta {ybest}")
+print(f"Reference solution: {target}")
+ratios = [x / y for x, y in zip(target, xbest)]
+print(f"Ratios of best to reference solution: {ratios}")

--- a/mystic/math/discrete.py
+++ b/mystic/math/discrete.py
@@ -874,27 +874,6 @@ Notes:
     pts = self.sampled_support(npts)
     return _maximum_given_samples(f, pts, map)
 
-  def sampled_probneg(self, f, npts=10000, map=None):
-    """use sampling to calculate probability of negativity for a given function
-
-Args:
-    f (func): a function that takes a list and returns a number
-    npts (int, default=10000): the number of point masses sampled from the
-        underlying discrete measures
-    map (func, default=builtins.map): the mapping function
-
-Returns:
-    the probability that ``f < 0``, a float in ``[0.0,1.0]``
-
-Notes:
-    - the function ``f`` should take a list of ``positions`` (for example,
-      ``scenario.positions`` or ``product_measure.positions``) and return a
-      single value (e.g. 0.0)
-"""
-    from mystic.math.samples import _probneg_given_samples
-    pts = self.sampled_support(npts)
-    return _probneg_given_samples(f, pts, map)
-
   def sampled_pof(self, f, npts=10000, map=None):
     """use sampling to calculate probability of failure for a given function
 

--- a/mystic/math/measures.py
+++ b/mystic/math/measures.py
@@ -18,20 +18,20 @@ from mystic.math import almostEqual
 from mystic.math.distance import Lnorm
 
 __all__ = ['weighted_select','spread','norm','maximum','ess_maximum',\
-          'minimum','ess_minimum','ptp','ess_ptp','expectation',\
-          'expected_variance','expected_std','_expected_moment','mean',\
-          'support_index','support','moment','standard_moment','variance',\
-          'std','skewness','kurtosis','impose_mean','impose_variance',\
-          'impose_std','impose_moment','impose_spread','impose_expectation',\
-          '_impose_expected_moment','impose_expected_variance',\
-          'impose_expected_std','impose_expected_mean_and_variance',\
-          'impose_weight_norm','normalize','impose_reweighted_mean',\
-          'impose_reweighted_variance','impose_reweighted_std','_sort',\
-          'median','mad','impose_median','impose_mad','_k','tmean',\
-          'tvariance','tstd','impose_tmean','impose_tvariance','impose_tstd',\
-          'impose_support','impose_unweighted','impose_collapse',\
-          'impose_sum','impose_product','_pack','_unpack','_flat',\
-          '_nested','_nested_split','split_param']
+           'minimum','ess_minimum','ptp','ess_ptp','expectation',\
+           'expected_variance','expected_std','_expected_moment','mean',\
+           'support_index','support','moment','standard_moment','variance',\
+           'std','skewness','kurtosis','impose_mean','impose_variance',
+           'impose_std','impose_moment','impose_spread','impose_expectation',\
+           '_impose_expected_moment','impose_expected_variance',\
+           'impose_expected_std','impose_expected_mean_and_variance',\
+           'impose_weight_norm','normalize','impose_reweighted_mean',\
+           'impose_reweighted_variance','impose_reweighted_std','_sort',\
+           'median','mad','impose_median','impose_mad','_k','tmean',\
+           'tvariance','tstd','impose_tmean','impose_tvariance','impose_tstd',\
+           'impose_support','impose_unweighted','impose_collapse',\
+           'impose_sum','impose_product','_pack','_unpack','_flat','_nested',\
+           '_nested_split','split_param']
 
 def weighted_select(samples, weights, mass=1.0):
   """randomly select a sample from weighted set of samples
@@ -154,7 +154,7 @@ Returns:
 def ptp(f, samples):
   """calculate the spread of function for the given list of points
 
-``minimum(f,x) = max(f(x)) - min(f(x))``
+``ptp(f,x) = max(f(x)) - min(f(x))``
 
 Args:
     f (func): a function that takes a list and returns a number
@@ -169,7 +169,7 @@ Returns:
 def ess_ptp(f, samples, weights=None, tol=0.):
   """calculate the spread of function for support on the given list of points
 
-``ess_minimum(f,x,w) = max(f(support(x,w))) - min(f(support(x,w)))``
+``ess_ptp(f,x,w) = max(f(support(x,w))) - min(f(support(x,w)))``
 
 Args:
     f (func): a function that takes a list and returns a number
@@ -203,6 +203,7 @@ Returns:
   # to prevent function evaluation if weight is "too small":
   # skip evaluation of f(x) if the corresponding weight <= tol
   #weights = normalize(weights, mass=1.0) #FIXME: below is atol, should be rtol?
+  from numpy import sum
   if not sum(abs(w) > tol for w in weights):
       yw = ((0.0,0.0),)
   else: #XXX: parallel map?
@@ -233,6 +234,7 @@ Returns:
     y = [f(x) for x in samples] #XXX: parallel map?
     return moment(y, weights, order) #XXX: tol?
   # skip evaluation of f(x) if the corresponding weight <= tol
+  from numpy import sum
   if not sum(abs(w) > tol for w in weights):
       yw = ((0.0,0.0),)
   else: #XXX: parallel map?
@@ -1343,6 +1345,7 @@ Notes: if mass='l1', will use L1-norm; if mass='l2' will use L2-norm; etc.
   weights = asarray(list(weights)) #XXX: faster to use x = array(x, copy=True) ?
 
   if fixed:
+    from numpy import sum
     w = sum(abs(weights))
   else:
     mass = int(min(200, mass)) # x**200 is ~ x**inf
@@ -1359,6 +1362,7 @@ Notes: if mass='l1', will use L1-norm; if mass='l2' will use L2-norm; etc.
     w = weights / w #FIXME: not "mean-preserving"
     if not fixed: return list(w) # <- scaled so sum(abs(x)) = 1
     #REMAINING ARE fixed mean
+    from numpy import sum
     m = sum(w)
     w = mass * w
     if not m:  #XXX: do similar to zsum (i.e. shift) when sum(weights)==0 ?

--- a/mystic/math/samples.py
+++ b/mystic/math/samples.py
@@ -177,21 +177,6 @@ Inputs:
   return _ptp_given_samples(f, pts, map)
 
 
-def sampled_probneg(f, lb, ub, npts=10000, map=None):
-  """
-use random sampling to calculate probability of negativity for a function
-
-Inputs:
-    f -- a function that takes a list and returns a number
-    lb -- a list of lower bounds
-    ub -- a list of upper bounds
-    npts -- the number of points to sample [Default is npts=10000]
-    map -- the mapping function [Default is builtins.map]
-"""
-  pts = _random_samples(lb, ub, npts)
-  return _probneg_given_samples(f, pts, map)
-
-
 def sampled_minimum(f, lb, ub, npts=10000, map=None):
   """
 use random sampling to calculate the minimum of a function
@@ -313,41 +298,6 @@ Inputs:
     from builtins import map
   from numpy import transpose, ptp, atleast_2d
   return ptp(list(map(f, atleast_2d(transpose(pts)).tolist())))
-
-
-def _probneg_given_samples(f, pts, map=None):
-  """
-use given sample pts to calculate probability of negativity for function f
-
-Inputs:
-    f -- a function that returns a single value, given a list of inputs
-    pts -- a list of sample points
-    map -- the mapping function [Default is builtins.map]
-"""
-  if map is None:
-    from builtins import map
-  from numpy import transpose, clip, count_nonzero, atleast_2d
-  results = list(map(f, atleast_2d(transpose(pts)).tolist()))
-  results = clip(results, None, 0) # negative-only
-  pneg = float(count_nonzero(results)) / float(results.size)
-  return pneg
-
-
-def _negativity_given_samples(f, pts, map=None):
-  """
-use given sample pts to calculate negativity of function f
-
-Inputs:
-    f -- a function that returns a single value, given a list of inputs
-    pts -- a list of sample points
-    map -- the mapping function [Default is builtins.map]
-"""
-  if map is None:
-    from builtins import map
-  from numpy import transpose, clip, atleast_2d
-  results = list(map(f, atleast_2d(transpose(pts)).tolist()))
-  neg = -clip(results, None, 0).sum() or 0.0
-  return neg
 
 
 def sampled_pts(pts, lb, ub, map=None):

--- a/mystic/tests/test_dirac_measure.py
+++ b/mystic/tests/test_dirac_measure.py
@@ -358,6 +358,11 @@ def test_min_max():
   assert c.sampled_minimum(f, 100) == -1
   assert c.sampled_maximum(f, 100) == 15
   assert c.sampled_ptp(f, 100) == 16
+
+  # negativity (round due to float precision)
+  positive = lambda x: f(x) >= 0
+  assert almostEqual(c.pof(positive), 0.1, tol=1e-2)
+  assert almostEqual(c.sampled_pof(positive, 10000), 0.1, tol=1e-2)
   return
 
 

--- a/mystic/tests/test_samples.py
+++ b/mystic/tests/test_samples.py
@@ -19,6 +19,9 @@ import mystic.models as mm
 def inside(x):
   import mystic.models as mm
   return mm.sphere(x) < 1
+def positive(x):
+  import mystic.models as mm
+  return mm.sphere(x) >= 0
 lb,ub = [0,0,0],[1,1,1]
 kwd = dict(tol=None, rel=.05)
 _kwd = dict(tol=.05, rel=None)
@@ -67,10 +70,10 @@ if pmap:
   a = ms.sampled_ptp(mm.sphere, lb[:2], ub[:2], npts=50000, map=pmap)
   assert my.math.approx_equal(a, ans, **_kwd)
 
-ans = ms.sampled_probneg(mm.sphere, lb, ub)
-assert my.math.approx_equal(ms.sampled_probneg(mm.sphere, lb[:1], ub[:1]), ans, **kwd)
+ans = ms.sampled_pof(positive, lb, ub)
+assert my.math.approx_equal(ms.sampled_pof(positive, lb[:1], ub[:1]), ans, **kwd)
 if pmap:
-  a = ms.sampled_probneg(mm.sphere, lb, ub, map=pmap)
+  a = ms.sampled_pof(positive, lb, ub, map=pmap)
   assert my.math.approx_equal(a, ans, **kwd)
 
 ans = ms.sampled_pof(inside, lb, ub)
@@ -94,6 +97,12 @@ assert my.math.approx_equal(ms._expectation_given_samples(mm.sphere, _pts) * 3, 
 if pmap:
   assert my.math.approx_equal(ms._expectation_given_samples(mm.sphere, pts), ms._expectation_given_samples(mm.sphere, pts, map=pmap), **kwd)
 
+ans = ms.sampled_variance(mm.sphere, lb, ub)
+assert my.math.approx_equal(ms._variance_given_samples(mm.sphere, pts), ans, **kwd)
+assert my.math.approx_equal(ms._variance_given_samples(mm.sphere, _pts) * 3, ans, **kwd)
+if pmap:
+  assert my.math.approx_equal(ms._variance_given_samples(mm.sphere, pts), ms._variance_given_samples(mm.sphere, pts, map=pmap), **kwd)
+
 assert 2.0 < ms._maximum_given_samples(mm.sphere, pts) < 3.5
 assert 0.9 < ms._maximum_given_samples(mm.sphere, _pts) < 1.1
 if pmap:
@@ -103,6 +112,11 @@ assert ms._maximum_given_samples(mm.sphere, pts) - ms._minimum_given_samples(mm.
 assert ms._maximum_given_samples(mm.sphere, _pts) - ms._minimum_given_samples(mm.sphere, _pts) == ms._ptp_given_samples(mm.sphere, _pts)
 if pmap:
   assert my.math.approx_equal(ms._ptp_given_samples(mm.sphere, pts), ms._ptp_given_samples(mm.sphere, pts, map=pmap), **kwd)
+
+assert 0.47 <= ms._pof_given_samples(inside, pts) < 0.48
+assert 0.00 <= ms._pof_given_samples(inside, _pts) < 0.01
+if pmap:
+  assert my.math.approx_equal(ms._pof_given_samples(positive, pts), ms._pof_given_samples(positive, pts, map=pmap), **kwd)
 
 assert my.math.approx_equal(ms.sampled_prob(pts, lb, ub), 1, **kwd)
 assert my.math.approx_equal(ms.sampled_prob(_pts, lb[:1], ub[:1]), 1, **kwd)


### PR DESCRIPTION
## Summary
add Variance and Negativity to examples3/ouq;
extend expected and sampled variance in samples and measures;
remove probneg and negativity from samples and measure, but use in tests
(as it's very derivative of pof)

## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Added relevant documentation that builds in sphinx without error.
- [x] Added new features that are documented with examples.
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added rationale for any breakage of backwards compatibility.