### PR TITLE
adjust fcalls in diffev2 for skipped cost

### DIFF
--- a/mystic/abstract_solver.py
+++ b/mystic/abstract_solver.py
@@ -167,7 +167,7 @@ Important class members::
 
     def __evaluations(self):
         """get the number of function calls"""
-        return self._fcalls[0]
+        return self._fcalls[0] #len(self._evalmon) or self._fcalls[0]
 
     def __generations(self):
         """get the number of iterations"""


### PR DESCRIPTION
## Summary
diffev2 has a less automatic tracking of function evaluations due to the use of a map function
potentially was overcounting when cost is skipped (returns `inf`)

fixes #246 

## Checklist
**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [ ] Added "Fixes #NNN" in the PR body, referencing the issue (#NNN) it closes.
- [ ] Added a comment to issue #NNN, linking back to this PR.
