### PR TITLE
replace items removed from numpy namespace

### DIFF
--- a/mystic/_scipy060optimize.py
+++ b/mystic/_scipy060optimize.py
@@ -21,7 +21,7 @@
 
 import numpy
 from numpy import atleast_1d, eye, mgrid, argmin, zeros, shape, empty, \
-     squeeze, isscalar, vectorize, asarray, absolute, sqrt, Inf, asfarray, isinf
+     squeeze, isscalar, vectorize, asarray, absolute, sqrt, Inf, isinf
 from mystic import linesearch
 from collections.abc import Callable as _Callable
 
@@ -169,7 +169,7 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
       of one or more variables.
       """
     fcalls, func = wrap_function(func, args)
-    x0 = asfarray(x0).flatten()
+    x0 = asarray(x0, dtype='float64').flatten()
     N = len(x0)
     rank = len(x0.shape)
     if not -1 < rank < 2:

--- a/mystic/_scipy060optimize.py
+++ b/mystic/_scipy060optimize.py
@@ -21,7 +21,7 @@
 
 import numpy
 from numpy import atleast_1d, eye, mgrid, argmin, zeros, shape, empty, \
-     squeeze, isscalar, vectorize, asarray, absolute, sqrt, Inf, isinf
+     squeeze, isscalar, vectorize, asarray, absolute, sqrt, inf, isinf
 from mystic import linesearch
 from collections.abc import Callable as _Callable
 
@@ -47,9 +47,9 @@ __version__="0.7"
 _epsilon = sqrt(numpy.finfo(float).eps)
 
 def vecnorm(x, ord=2):
-    if ord == Inf:
+    if ord == inf:
         return numpy.amax(abs(x))
-    elif ord == -Inf:
+    elif ord == -inf:
         return numpy.amin(abs(x))
     else:
         return numpy.sum(abs(x)**ord,axis=0)**(1.0/ord)
@@ -626,7 +626,7 @@ def approx_fhess_p(x0,p,fprime,epsilon,*args):
     f1 = fprime(*((x0,)+args))
     return (f2 - f1)/epsilon
 
-def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf,
+def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=inf,
               epsilon=_epsilon, maxiter=None, full_output=0, disp=1,
               retall=0, callback=None):
     """Minimize a function using the BFGS algorithm.
@@ -642,7 +642,7 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf,
       gtol : number
         gradient norm must be less than gtol before succesful termination
       norm : number
-        order of norm (Inf is max, -Inf is min)
+        order of norm (inf is max, -inf is min)
       epsilon : number
         if fprime is approximated use this value for
                  the step size (can be scalar or vector)
@@ -812,7 +812,7 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf,
 
     return retlist
 
-def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=Inf, epsilon=_epsilon,
+def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=inf, epsilon=_epsilon,
               maxiter=None, full_output=0, disp=1, retall=0, callback=None):
     """Minimize a function with nonlinear conjugate gradient algorithm.
 

--- a/mystic/abstract_solver.py
+++ b/mystic/abstract_solver.py
@@ -74,7 +74,7 @@ __all__ = ['AbstractSolver']
 
 import random
 import numpy
-from numpy import inf, shape, asarray, absolute, asfarray, seterr
+from numpy import inf, shape, asarray, absolute, seterr
 from mystic.tools import wrap_function, wrap_nested, wrap_reducer
 from mystic.tools import wrap_bounds, wrap_penalty, reduced
 from klepto import isvalid, validate
@@ -472,7 +472,7 @@ Args:
 Returns:
     None
         """
-        x0 = asfarray(x0)
+        x0 = asarray(x0, dtype='float64')
         rank = len(x0.shape)
         if rank == 0:
             x0.shape = (1,)
@@ -482,7 +482,7 @@ Returns:
         if len(x0) != self.nDim:
             raise ValueError("Initial guess must be length %s" % self.nDim)
 
-        radius = asfarray(radius) # may be scalar or a nDim array
+        radius = asarray(radius, dtype='float64') # maybe scalar or a nDim array
         _rank = len(radius.shape)
 
         if _rank and len(radius) != self.nDim:

--- a/mystic/collapse.py
+++ b/mystic/collapse.py
@@ -9,6 +9,7 @@
 
 import mystic.monitors as _m
 inf = _m.numpy.inf
+np = _m.numpy
 
 ##### parameter collapse detectors #####
 def collapse_at(stepmon, target=None, tolerance=0.005, \
@@ -38,7 +39,7 @@ def collapse_at(stepmon, target=None, tolerance=0.005, \
     tolerance = np.asarray(tolerance)
     tolerance.shape = (-1,1)
     params = _m._solutions(stepmon, generations)
-    if target is None: params = params.ptp(axis=0) <= tolerance
+    if target is None: params = np.ptp(params, axis=0) <= tolerance
     else: params = abs(params - target).max(axis=0) <= tolerance
     # get tuple of indices of where collapsed
     params = np.where(params)[-1]
@@ -84,7 +85,7 @@ def collapse_as(stepmon, offset=False, tolerance=0.005, \
     from mystic.tools import pairwise
     distances, pairs = pairwise(distances, True)
     if offset: # tracking at a distance
-        distances = distances.ptp(axis=0) <= tolerance
+        distances = np.ptp(distances, axis=0) <= tolerance
     else: # tracking with the same position
         distances = distances.max(axis=0) <= tolerance
     # get the (index1,index2) pairs where the collapse occurs

--- a/mystic/constraints.py
+++ b/mystic/constraints.py
@@ -720,7 +720,7 @@ NOTE:
     return cf
 
 
-from numpy import asfarray, asarray, choose, zeros, ones, ndarray
+from numpy import asarray, choose, zeros, ones, ndarray
 from numpy import shape, broadcast, empty, atleast_1d
 #from random import sample, choice
 def discrete(samples, index=None):
@@ -1208,7 +1208,7 @@ def bounded(seq, bounds, index=None, clip=True, nearest=True):
     if bounds is None or not bounds: return seq
     if isinstance(index, int): index = (index,)
     if not hasattr(bounds[0], '__len__'): bounds = (bounds,)
-    bounds = asfarray(bounds).T  # is [(min,min,...),(max,max,...)]
+    bounds = asarray(bounds, dtype='float64').T # [(min,min,...),(max,max,...)]
     # convert None to -inf or inf
     bounds[0][isnan(bounds[0])] = -inf
     bounds[1][isnan(bounds[1])] = inf

--- a/mystic/differential_evolution.py
+++ b/mystic/differential_evolution.py
@@ -147,7 +147,7 @@ from mystic.tools import wrap_bounds, wrap_penalty, reduced
 from mystic.abstract_solver import AbstractSolver
 from mystic.abstract_map_solver import AbstractMapSolver
 
-from numpy import asfarray, ravel, isinf
+from numpy import asarray, ravel, isinf
 from collections.abc import Callable as _Callable
 
 class DifferentialEvolutionSolver(AbstractSolver):
@@ -280,7 +280,7 @@ Notes:
         if not len(self._stepmon): # do generation = 0
             init = True
             strategy = None
-            self.population[0] = asfarray(self.population[0])
+            self.population[0] = asarray(self.population[0], dtype='float64')
             # decouple bestSolution from population and bestEnergy from popEnergy
             bs = self.population[0]
             self.bestSolution = bs.copy() if hasattr(bs, 'copy') else bs[:]
@@ -529,7 +529,7 @@ Notes:
         if not len(self._stepmon): # do generation = 0
             init = True
             strategy = None
-            self.population[0] = asfarray(self.population[0])
+            self.population[0] = asarray(self.population[0], dtype='float64')
             # decouple bestSolution from population and bestEnergy from popEnergy
             bs = self.population[0]
             self.bestSolution = bs.copy() if hasattr(bs, 'copy') else bs[:]

--- a/mystic/math/_rbf.py
+++ b/mystic/math/_rbf.py
@@ -199,7 +199,7 @@ class Rbf(object):
         return a0
 
     def __init__(self, *args, **kwargs):
-        self.xi = np.asarray([np.asarray(a, dtype=np.float_).flatten()
+        self.xi = np.asarray([np.asarray(a, dtype=np.float64).flatten()
                            for a in args[:-1]])
         self.N = self.xi.shape[-1]
         self.di = np.asarray(args[-1]).flatten()
@@ -254,6 +254,6 @@ class Rbf(object):
         if not all([x.shape == y.shape for x in args for y in args]):
             raise ValueError("Array lengths must be equal")
         shp = args[0].shape
-        xa = np.asarray([a.flatten() for a in args], dtype=np.float_)
+        xa = np.asarray([a.flatten() for a in args], dtype=np.float64)
         r = self._call_norm(xa, self.xi)
         return np.dot(self._function(r), self.nodes).reshape(shp)

--- a/mystic/math/approx.py
+++ b/mystic/math/approx.py
@@ -100,7 +100,7 @@ def almostEqual(x, y, tol=1e-18, rel=1e-7):
     -------
     y : bool
         Returns True if the two arrays are equal within the given
-        tolerance; False otherwise. If either array contains NaN, then
+        tolerance; False otherwise. If either array contains nan, then
         False is returned.
 
     Notes

--- a/mystic/scipy_optimize.py
+++ b/mystic/scipy_optimize.py
@@ -88,7 +88,7 @@ from mystic.tools import wrap_function, unpair, wrap_nested
 from mystic.tools import wrap_bounds, wrap_penalty, reduced
 
 import numpy
-from numpy import eye, zeros, shape, asarray, absolute, asfarray
+from numpy import eye, zeros, shape, asarray, absolute
 from numpy import clip, squeeze
 
 abs = absolute
@@ -262,8 +262,8 @@ Notes:
         if not len(self._stepmon): # do generation = 0
             init = True
             x0 = self.population[0]
-            x0 = asfarray(x0).flatten()
-            x0 = asfarray(constraints(x0))
+            x0 = asarray(x0, dtype='float64').flatten()
+            x0 = asarray(constraints(x0), dtype='float64')
             #####XXX: this blows away __init__, so replace __init__ with this?
             N = len(x0)
             rank = len(x0.shape)
@@ -301,7 +301,7 @@ Notes:
             one2np1 = range(1,N+1)
 
             # apply constraints  #XXX: is this the only appropriate place???
-            sim[0] = asfarray(constraints(sim[0]))
+            sim[0] = asarray(constraints(sim[0]), dtype='float64')
 
             xbar = numpy.add.reduce(sim[:-1],0) / N
             xr = (1+rho)*xbar - rho*sim[-1]
@@ -646,8 +646,8 @@ Notes:
 
         if not len(self._stepmon): # do generation = 0
             init = True
-            x = asfarray(x).flatten()
-            x = asfarray(constraints(x))
+            x = asarray(x, dtype='float64').flatten()
+            x = asarray(constraints(x), dtype='float64')
             N = len(x) #XXX: this should be equal to self.nDim
             rank = len(x.shape)
             if not -1 < rank < 2:
@@ -680,7 +680,7 @@ Notes:
                     bigind = i
 
                 # apply constraints
-                x = asfarray(constraints(x)) #XXX: use self._map?
+                x = asarray(constraints(x), dtype='float64') #XXX: self._map?
             # decouple from 'best' energy
             self.energy_history = self.energy_history + [fval]
 
@@ -702,7 +702,7 @@ Notes:
                     direc[bigind] = direc[-1]
                     direc[-1] = direc1
 
-           #        x = asfarray(constraints(x))
+           #        x = asarray(constraints(x), dtype='float64')
 
             self._direc = direc
             self.population[0] = x   # bestSolution
@@ -726,7 +726,7 @@ Notes:
                     bigind = i
 
                 # apply constraints
-                x = asfarray(constraints(x)) #XXX: use self._map?
+                x = asarray(constraints(x), dtype='float64') #XXX: self._map?
 
             # decouple from 'best' energy
             self.energy_history = self.energy_history + [fval]

--- a/mystic/scripts.py
+++ b/mystic/scripts.py
@@ -1077,7 +1077,7 @@ Notes:
       For finer control, provide an array[float] the same length as ``params``.
 """
     #FIXME: should be able to:
-    # - apply a constraint as a region of NaN -- apply when 'xx,yy=x[ij],y[ij]'
+    # - apply a constraint as a region of nan -- apply when 'xx,yy=x[ij],y[ij]'
     # - apply a penalty by shifting the surface (plot w/alpha?) -- as above
     # - build an appropriately-sized default grid (from logfile info)
     # - move all mulit-id param/cost reading into read_history

--- a/mystic/termination.py
+++ b/mystic/termination.py
@@ -12,6 +12,7 @@ Factories that provide termination conditions for a mystic.solver
 """
 
 import numpy
+np = numpy
 abs = numpy.absolute
 inf = numpy.inf
 nan = numpy.nan

--- a/mystic/termination.py
+++ b/mystic/termination.py
@@ -13,8 +13,8 @@ Factories that provide termination conditions for a mystic.solver
 
 import numpy
 abs = numpy.absolute
-inf = Inf = numpy.Inf
-nan = NaN = numpy.NaN
+inf = numpy.inf
+nan = numpy.nan
 null = ""
 _type = type #NOTE: save builtin type
 import mystic.collapse as ct #XXX: avoid if move Collapse* to collapse
@@ -355,7 +355,7 @@ def PopulationSpread(tolerance=1e-6):
     _PopulationSpread.__doc__ = doc
     return _PopulationSpread
 
-def GradientNormTolerance(tolerance=1e-5, norm=Inf): 
+def GradientNormTolerance(tolerance=1e-5, norm=inf): 
     """gradient norm is < tolerance, given user-supplied norm:
 
 ``sum( abs(gradient)**norm )**(1.0/norm) <= tolerance``
@@ -389,8 +389,8 @@ or number of function calls is > evaluations:
                                         'evaluations':evaluations}
     maxfun = [evaluations]
     maxiter = [generations]
-    if maxfun[0] is None: maxfun[0] = Inf 
-    if maxiter[0] is None: maxiter[0] = Inf
+    if maxfun[0] is None: maxfun[0] = inf 
+    if maxiter[0] is None: maxiter[0] = inf
     def _EvaluationLimits(inst, info=False):
         if info: info = lambda x:x
         else: info = bool
@@ -421,7 +421,7 @@ def TimeLimits(seconds=86400, system=None): #NOTE: 24 hours
     def _reset():
         start[0] = timer()
     delta = [getattr(seconds, 'total_seconds', seconds.__abs__)()]
-    if delta[0] is None: delta[0] = Inf
+    if delta[0] is None: delta[0] = inf
     def _TimeLimits(inst, info=False):
         if info: info = lambda x:x
         else: info = bool

--- a/mystic/tests/test_termination.py
+++ b/mystic/tests/test_termination.py
@@ -16,7 +16,7 @@ SolutionImprovement(tolerance=1e-5)
 NormalizedCostTarget(fval=None, tolerance=1e-6, generations=30)
 VTRChangeOverGeneration(ftol=0.005, gtol=1e-6, generations=30)
 PopulationSpread(tolerance=1e-6)
-GradientNormTolerance(tolerance=1e-5, norm=Inf)
+GradientNormTolerance(tolerance=1e-5, norm=inf)
 EvaluationLimits(generations=None, evaluations=None)
 TimeLimits(seconds=86400, system=None)
 """
@@ -190,7 +190,7 @@ if __name__ == "__main__":
 while test05-test06 returns a ndarray for population, popEnergy, bestSolution;
 test07-test08 throw a RuntimeError "Too many iterations" due to "bracket()".
   For x:inf, test01-test02 have 1e+20 in energy_history, popEnergy, bestEnergy;
-while test03-test04 have inf; test05-test06 have Inf in popEnergy;
+while test03-test04 have inf; test05-test06 have inf in popEnergy;
 while test07-test08 have array(inf) for energy_history, popEnergy,
 and inf for bestEnergy, and energy_history, popEnergy, population is list
 of ndarrays, while bestSolution is an ndarray.

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ klepto_version = 'klepto>=0.2.5'
 pathos_version = 'pathos>=0.3.2'
 pyina_version = 'pyina>=0.2.9'
 cython_version = 'cython>=0.29.30' #XXX: required to build numpy from source
-numpy_version = 'numpy>=1.0'
+numpy_version = 'numpy>=1.0, <2.0.0b1'
 sympy_version = 'sympy>=0.6.7'#, <0.7.4'
 scipy_version = 'scipy>=0.6.0'
 mpmath_version = 'mpmath>=0.19'


### PR DESCRIPTION
## Summary
`numpy.asfarray` has been deprecated and removed. replace it with `numpy.asarray` of `dtype='float64'`
similarly, for `Inf, `NaN`, and `float_`.  Also, `array.ptp` has been removed.
See: https://numpy.org/devdocs/numpy_2_0_migration_guide.html

## Checklist
**Documentation and Tests**
- [x] Artifacts produced with the main branch work as expected under this PR.