### PR TITLE
SetTermination to None to only use EvaluationLimits

### DIFF
--- a/mystic/abstract_solver.py
+++ b/mystic/abstract_solver.py
@@ -717,7 +717,13 @@ Notes:
         """set the termination conditions
 
 input::
-    - termination = termination conditions to check against"""
+    - termination = termination conditions to check against
+
+note::
+    terminates a solver due to 'termination' or the inherent EvaluationLimits
+
+note::
+    SetTermination(None) sets termination to the inherent EvaluationLimits"""
         #XXX: validate that termination is a 'condition' ?
         self._termination = termination
         self._collapse = False
@@ -726,6 +732,8 @@ input::
             stop = state(termination)
             stop = stop.keys()
             self._collapse = any(key.startswith('Collapse') for key in stop)
+        else:
+            self._termination = AbstractSolver(self.nDim)._termination
         return
 
     def SetObjective(self, cost, ExtraArgs=None):  # callback=None/False ?


### PR DESCRIPTION
## Summary
simplify the ability to have the solver only rely on the inherent EvaluationLimits.
passing `termination=None` should essentially remove the termination condition (and purely use maxiter and maxfun).

## Checklist
**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Added relevant documentation that builds in sphinx without error.
- [ ] Added new features that are documented with examples.
- [ ] Artifacts produced with the main branch work as expected under this PR.