### PR TITLE
add constrained torch and keras examples

### DIFF
--- a/examples3/constrained_scikeras.py
+++ b/examples3/constrained_scikeras.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+#
+# Author: Mike McKerns (mmckerns @caltech and @uqfoundation)
+# Copyright (c) 2024 The Uncertainty Quantification Foundation.
+# License: 3-clause BSD.  The full license text is available at:
+#  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
+"""
+  Example applying mystic to keras with scikeras
+
+  Use a linear regression to fit sparse data generated from:
+            f(x) = a*x3**3 + b*x2**2 + c*x1 + d*x0
+            a,b,c,d = 0.661, -1.234, 2.983, -16.5571
+
+  Where the following information is utilized: 
+            f(x) is a polynomial of order=3
+            3*b + c > -0.75
+            4.5*b - d > 11.0
+"""
+import warnings
+from tensorflow import get_logger
+get_logger().setLevel('ERROR')
+warnings.filterwarnings("ignore", message="setting tensorflow random state")
+import numpy as np
+import scikeras
+from scikeras.wrappers import KerasRegressor
+
+
+class LinearRegression(KerasRegressor):
+    def __init__(self, hidden_layer_sizes=(100,),
+                 optimizer="adam", optimizer__learning_rate=0.001,
+                 epochs=200, verbose=0, **kwargs):
+        super().__init__(**kwargs)
+        self.hidden_layer_sizes = hidden_layer_sizes
+        self.optimizer = optimizer
+        self.epochs = epochs
+        self.verbose = verbose
+
+    def _keras_build_fn(self, compile_kwargs):
+        import keras
+        model = keras.Sequential()
+        inp = keras.layers.Input(shape=(self.n_features_in_,))
+        model.add(inp)
+        for hidden_layer_size in self.hidden_layer_sizes:
+            layer = keras.layers.Dense(hidden_layer_size, activation="relu")
+            model.add(layer)
+        out = keras.layers.Dense(1)
+        model.add(out)
+        model.compile(loss="mse", optimizer=compile_kwargs["optimizer"])
+        return model
+
+
+if __name__=='__main__':
+    # build a kernel-transformed regressor
+    from constrained_sklearn import *
+    ta = pre.FunctionTransformer(func=vectorize(cf, axis=1))
+    tp = pre.PolynomialFeatures(degree=3)
+    e = LinearRegression()
+
+    # build a pipeline, then train
+    from sklearn.pipeline import Pipeline
+    pipe = Pipeline([('ta', ta), ('tp', tp), ('e', e)])
+    pipe = pipe.fit(xtrain, target)
+
+    # get training score and test score
+    assert 1 - pipe.score(xtrain, target) <= 1e-4
+    assert 1 - pipe.score(xtest, test) <= 1e-1

--- a/examples3/constrained_sklearn.py
+++ b/examples3/constrained_sklearn.py
@@ -52,10 +52,13 @@ if __name__ == '__main__':
     tp = pre.PolynomialFeatures(degree=3)
     e = lin.LinearRegression()
 
-    # train and score, then test and score
-    xtrain_ = tp.fit_transform(ta.fit_transform(xtrain))
-    assert 1.0 == e.fit(xtrain_, target).score(xtrain_, target)
-    xtest_ = tp.fit_transform(ta.fit_transform(xtest))
-    assert 1 - e.score(xtest_, test) <= 1e-2
+    # build a pipeline, then train
+    from sklearn.pipeline import Pipeline
+    pipe = Pipeline([('ta', ta), ('tp', tp), ('e', e)])
+    pipe = pipe.fit(xtrain, target)
+
+    # get training score and test score
+    assert 1.0 == pipe.score(xtrain, target)
+    assert 1 - pipe.score(xtest, test) <= 1e-2
 
 # EOF

--- a/examples3/constrained_skorch.py
+++ b/examples3/constrained_skorch.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+#
+# Author: Mike McKerns (mmckerns @caltech and @uqfoundation)
+# Copyright (c) 2024 The Uncertainty Quantification Foundation.
+# License: 3-clause BSD.  The full license text is available at:
+#  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
+"""
+  Example applying mystic to torch with skorch
+
+  Use a linear regression to fit sparse data generated from:
+            f(x) = a*x3**3 + b*x2**2 + c*x1 + d*x0
+            a,b,c,d = 0.661, -1.234, 2.983, -16.5571
+
+  Where the following information is utilized: 
+            f(x) is a polynomial of order=3
+            3*b + c > -0.75
+            4.5*b - d > 11.0
+"""
+import torch
+import numpy as np
+import torch.nn as nn
+import skorch
+from skorch import NeuralNetRegressor
+from torch.optim.lr_scheduler import StepLR
+from skorch.callbacks.lr_scheduler import LRScheduler
+import torch.optim as optim
+
+
+class LinearRegression(nn.Module):
+    def __init__(self, n_in, n_h=100, n_layers=1, dropout=0.0):
+        super().__init__()
+        self.n_in = n_in
+        self.layers = nn.ModuleList()
+        self.layers.append(nn.Linear(n_in, n_h))
+        self.layers.append(nn.Dropout(dropout))
+        self.layers.append(nn.ReLU())
+        for _ in range(n_layers):
+            self.layers.append(nn.Linear(n_h, n_h))
+            self.layers.append(nn.Dropout(dropout))
+            self.layers.append(nn.ReLU())
+        self.layers.append(nn.Linear(n_h, 1))
+
+    def forward(self, x):
+        y = x.view(-1, self.n_in)
+        for _, layer in enumerate(self.layers):
+            y = layer(y)
+        return y
+
+
+if __name__=='__main__':
+    # convert training and test data to the format used by torch
+    from constrained_sklearn import *
+    target = target.reshape(target.shape[0], -1).astype(np.float32)
+    xtrain = xtrain.astype(np.float32)
+    test = test.reshape(test.shape[0], -1).astype(np.float32)
+    xtest = xtest.astype(np.float32)
+
+    # build a kernel-transformed regressor
+    ta = pre.FunctionTransformer(func=vectorize(cf, axis=1))
+    tp = pre.PolynomialFeatures(degree=3)
+    n_in = tp.fit_transform(ta.fit_transform(xtrain)).shape[1]
+    lr_policy = LRScheduler(StepLR, step_size=15, gamma=0.5)
+    e = NeuralNetRegressor(LinearRegression, criterion=torch.nn.MSELoss,
+                           module__n_in=n_in, module__n_h=300,
+                           module__n_layers=3, module__dropout=0.2,
+                           optimizer=torch.optim.Adam, optimizer__lr=.005,
+                           max_epochs=200, callbacks=[lr_policy],
+                           device='cpu', batch_size=64, verbose=0)
+
+    # build a pipeline, then train
+    from sklearn.pipeline import Pipeline
+    pipe = Pipeline([('ta', ta), ('tp', tp), ('e', e)])
+    pipe = pipe.fit(xtrain, target)
+
+    # get training score and test score
+    assert 1 - pipe.score(xtrain, target) <= 1e-1
+    assert 1 - pipe.score(xtest, test) <= 1e-1


### PR DESCRIPTION
## Summary
add examples using mystic for unsupervised learning in linear regressors from torch and keras

## Checklist
**Documentation and Tests**
- [x] Added relevant documentation that builds in sphinx without error.
- [x] Artifacts produced with the main branch work as expected under this PR.