### PR TITLE
enable modification of NP for diffev in sampler

### DIFF
--- a/mystic/abstract_ensemble_solver.py
+++ b/mystic/abstract_ensemble_solver.py
@@ -205,7 +205,8 @@ Returns:
        #evalmon = Monitor()
        #maxiter = 1000
        #maxfun = 1e+6
-        solver = solver(self.nDim)
+        NP = getattr(solver, 'NP', None) #HACK: if solver has NP, use it
+        solver = solver(self.nDim) if NP is None else solver(self.nDim, NP)
         solver.SetRandomInitialPoints() #FIXME: set population; will override
         if self._useStrictRange: #XXX: always, settable, or sync'd ?
             solver.SetStrictRanges(min=self._strictMin, \

--- a/mystic/abstract_sampler.py
+++ b/mystic/abstract_sampler.py
@@ -46,7 +46,15 @@ Args:
 
         # apply additional kwds
         solver = self._kwds['solver']
-        if solver is not None: s.SetNestedSolver(solver)
+        if solver is not None:
+            if not hasattr(solver, 'nPop'):
+                #HACK: add NP attribute if NP provided
+                NP = self._kwds['NP']
+                solver.NP = NP
+            elif 'NP' in kwds:
+                msg = "cannot modify 'nPop' for configured solver"
+                raise NotImplementedError(msg)
+            s.SetNestedSolver(solver)
         s.id = self._kwds['id']
         s.SetDistribution(self._kwds['dist'])
         s.SetEvaluationLimits(self._kwds['maxiter'], self._kwds['maxfun'])


### PR DESCRIPTION
## Summary
When the solver keyword is used in a sampler, other solver keywords can be provided to configure the solver. However, when the solver takes an extra __init__ arg, that cannot be changed (but should be allowed).  A small hack is applied to pass additional args to __init__ for the solver.

## Checklist
**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Added relevant documentation that builds in sphinx without error.
- [ ] Added new features that are documented with examples.
- [x] Artifacts produced with the main branch work as expected under this PR.