### PR TITLE
handle np.float in logfile, getitem preserves settings

### DIFF
--- a/mystic/monitors.py
+++ b/mystic/monitors.py
@@ -193,6 +193,10 @@ example usage...
             m._x = self._x[y]
             m._y = self._y[y]
             m._id = self._id[y]
+        # copy other internals
+        m.k = self.k
+        m.label = self.label
+        m._npts = self._npts
         return m
 
     def __setitem__(self, i, y):
@@ -415,6 +419,13 @@ input parameters 'x' every 'xinterval'.
             if id is not None: msg = "[id: %s] " % (id) + msg
             print(msg)
         return
+    def __getitem__(self, y):
+        """x.__getitem__(y) <==> x[y]"""
+        m = super(VerboseMonitor,self).__getitem__(y)
+        if hasattr(m, '_yinterval'): m._yinterval = self._yinterval
+        if hasattr(m, '_xinterval'): m._xinterval = self._xinterval
+        if hasattr(m, '_all'): m._all = self._all
+        return m
     pass
 
 class LoggingMonitor(Monitor):
@@ -491,6 +502,15 @@ Logs output 'y' and input parameters 'x' to a file every 'interval'.
     def __setstate__(self, state):
         self.__dict__.update(state)
         return
+    def __getitem__(self, y):
+        """x.__getitem__(y) <==> x[y]"""
+        m = super(LoggingMonitor,self).__getitem__(y)
+        if hasattr(m, '_yinterval'): m._yinterval = self._yinterval
+        if hasattr(m, '_xinterval'): m._xinterval = self._xinterval
+        if hasattr(m, '_all'): m._all = self._all
+        if hasattr(m, '_filename'): m._filename = self._filename
+        if hasattr(m, '_file'): m._file = self._file
+        return m
     pass
 
 class VerboseLoggingMonitor(LoggingMonitor):
@@ -556,6 +576,16 @@ print every 'yinterval'.
     def __setstate__(self, state):
         self.__dict__.update(state)
         return
+    def __getitem__(self, y):
+        """x.__getitem__(y) <==> x[y]"""
+        m = super(VerboseLoggingMonitor,self).__getitem__(y)
+        if hasattr(m, '_yinterval'): m._yinterval = self._yinterval
+        if hasattr(m, '_xinterval'): m._xinterval = self._xinterval
+        if hasattr(m, '_all'): m._all = self._all
+        if hasattr(m, '_filename'): m._filename = self._filename
+        if hasattr(m, '_file'): m._file = self._file
+        if hasattr(m, '_vyinterval'): m._vyinterval = self._vyinterval
+        if hasattr(m, '_vxinterval'): m._vxinterval = self._vxinterval
     pass
 
 def CustomMonitor(*args,**kwds):

--- a/mystic/munge.py
+++ b/mystic/munge.py
@@ -107,7 +107,8 @@ def logfile_reader(filename, iter=False):
   If iter=True, returns tuple of (iter, params, energy), as defined above.
   If iter=False, returns tuple of (params, energy).
   """
-  from numpy import inf, nan
+  import numpy as np
+  inf, nan = np.inf, np.nan
   f = open(filename,"r")
   file = f.read()
   f.close()


### PR DESCRIPTION
## Summary
- np.float may be written to logfile, so needs to have numpy imported as np
- when getting a slice of a monitor, getitem should preserve monitor internal settings

## Checklist

<!-- Please delete any checkboxes that do not apply to this PR. -->

**Documentation and Tests**
- [ ] Added relevant documentation that builds in sphinx without error.
- [ ] Added new features that are documented with examples.
- [ ] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [ ] Added rationale for any breakage of backwards compatibility.

