### PR TITLE
weighting and multiplication for joined Distributions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,16 +37,16 @@ matrix:
         - python: 'pypy3.9-7.3.9' # at 7.3.16
           env:
 
-        - python: 'pypy3.10-7.3.18'
+        - python: 'pypy3.10-7.3.19'
           env:
 
-        - python: 'pypy3.11-7.3.18'
+        - python: 'pypy3.11-7.3.19'
           env:
 
     allow_failures:
         - python: '3.14-dev' # CI missing
-        - python: 'pypy3.10-7.3.18' # CI missing
-        - python: 'pypy3.11-7.3.18' # CI missing
+        - python: 'pypy3.10-7.3.19' # CI missing
+        - python: 'pypy3.11-7.3.19' # CI missing
     fast_finish: true
 
 cache:

--- a/mystic/tests/test_distribution.py
+++ b/mystic/tests/test_distribution.py
@@ -18,9 +18,16 @@ apb2= (a+b)/2
 anb = Distribution(a,b)
 bnc = Distribution(b,c)
 bpc2 = (b+c)/2
+amb = a*b
+a0nb = Distribution(a,b,p=(0,1))
+a4nb6 = Distribution(a,b,p=(.4,.6))
+anc = Distribution(a,c,p=(.5,.5))
 
 assert almostEqual(a2pb2(N).mean(), apb2(N).mean(), tol=.1)
 assert almostEqual(anb(N).mean(), .5*apb(N).mean(), tol=.1)
+assert almostEqual(anb(N).mean(), amb(N).mean(), tol=.1)
 assert almostEqual((a(N).mean() + b(N).mean())/2, apb2(N).mean(), tol=.1)
 assert almostEqual((b(N).mean() + c(N).mean())/2, bpc2(N).mean(), tol=.1)
 assert almostEqual((a+b+c)(N).mean(), (c+b+a)(N).mean(), tol=.1)
+assert almostEqual(a0nb(N).mean(), b(N).mean(), tol=.1)
+assert almostEqual(a4nb6(N).mean(), anc(N).mean(), tol=.1)


### PR DESCRIPTION
## Summary
Let `a * b` to be identical to `Distribution(a, b)`, where `a` and `b` are `Distribution` instances.
Enable `Distribution(a, b)` to take "weights" such that the probability to choose from `a` or `b` is not uniform.


## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Added relevant documentation that builds in sphinx without error.
- [ ] Added new features that are documented with examples.
- [x] Artifacts produced with the main branch work as expected under this PR.