### PR TITLE
sync InterpModel and LearnedModel ouq_model API and extend to 2d

### DIFF
--- a/examples3/constrained_skorch.py
+++ b/examples3/constrained_skorch.py
@@ -49,8 +49,18 @@ class LinearRegression(nn.Module):
             y = layer(y)
         if self.n_ny is None:
             y = y.reshape(-1)
-        else: y = y.reshape(self.n_ny, -1)
+        else: y = y.reshape(-1, self.n_ny)
         return y.to(torch.float64)
+
+
+class NetRegressor(NeuralNetRegressor):
+
+    def fit(self, X, y, **kwds):
+        return super().fit(np.asarray(X), np.asarray(y), **kwds)
+
+    def predict(self, X, **kwds):
+        return super().predict(np.asarray(X), **kwds)
+
 
 
 if __name__=='__main__':
@@ -60,12 +70,12 @@ if __name__=='__main__':
     tp = pre.PolynomialFeatures(degree=3)
     n_nx = tp.fit_transform(ta.fit_transform(xtrain)).shape[1]
     lr_policy = LRScheduler(StepLR, step_size=15, gamma=0.5)
-    e = NeuralNetRegressor(LinearRegression, criterion=torch.nn.MSELoss,
-                           train_split=None, module__n_nx=n_nx, module__n_h=300,
-                           module__n_layers=3, module__dropout=0.2,
-                           optimizer=torch.optim.Adam, optimizer__lr=.005,
-                           max_epochs=200, callbacks=[lr_policy],
-                           device='cpu', batch_size=64, verbose=0)
+    e = NetRegressor(LinearRegression, criterion=torch.nn.MSELoss,
+                     train_split=None, module__n_nx=n_nx, module__n_h=300,
+                     module__n_layers=3, module__dropout=0.2,
+                     optimizer=torch.optim.Adam, optimizer__lr=.005,
+                     max_epochs=200, callbacks=[lr_policy],
+                     device='cpu', batch_size=64, verbose=0)
 
     # build a pipeline, then train
     from sklearn.pipeline import Pipeline

--- a/examples3/interpolator.py
+++ b/examples3/interpolator.py
@@ -150,7 +150,7 @@ class Interpolator(object):
         from mystic.math.interpolate import interpf
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore')
-            f = interpf(x, z, **kwds)
+            f = interpf(x, z, **kwds) #FIXME: assumes Rbf(x,z), not Rbf(*X,z)
         return f
 
 
@@ -228,6 +228,10 @@ class Interpolator(object):
         from mystic.math.interpolate import _to_objective
         _objective = _to_objective(self.function)
         def objective(x, *args, **kwds):
+            if hasattr(x, '__len__'):
+                # interpf has f(*x.T); want model(x) so consistent with Learned 
+                import numpy as np
+                x = np.asarray(x).T
             result = _objective(x, *args, **kwds)
             return result.tolist() if hasattr(result, 'tolist') else result
         objective.__doc__ = _objective.__doc__

--- a/examples3/ml.py
+++ b/examples3/ml.py
@@ -44,7 +44,17 @@ class Estimator(object): #XXX: use pipeline?
             import sklearn.preprocessing as pre
             transform = pre.FunctionTransformer() #XXX: or StandardScaler ?
         self.transform = transform
-        self.function = lambda *x: float(self.test(np.array(x).reshape(1,-1)).reshape(-1))
+        def function(*x):
+            x = np.atleast_2d(x)
+            n = x.shape[0]
+            x = self.test(x).reshape(n,-1).squeeze()
+            n = x.ndim
+            x = x.tolist()
+            #if n == 0: return x
+            #if n == 1: return tuple(x)
+            #if n == 2: return [tuple(i) for i in x]
+            return x #TODO: n-1th dimension should be tuples
+        self.function = function
     def __call__(self, *x):
         "f(*x) for x of xtest and predict on fitted estimator(transform(xtest))"
         import numpy as np

--- a/examples3/ouq.py
+++ b/examples3/ouq.py
@@ -271,6 +271,7 @@ class BaseOUQ(object): #XXX: redo with a "Solver" interface, like ensemble?
             penalty = linear_equality(lambda rv, ave: abs(ave - self._cost[axis]), kwds={'ave':self._ave[axis]}, k=kpen)(lambda rv: 0.)
             # stop at exact cost, however if noisy stop within variance
             ftol = 1e-16 if self.samples is None else self._var[axis]
+            ftol = self.kwds.get('ftol', ftol) #FIXME: doc user provided ftol
             from mystic.termination import VTR
             stop = VTR(ftol, self._ave[axis])
             # solve for expected value of objective (in measure space)
@@ -574,7 +575,7 @@ class BaseOUQ(object): #XXX: redo with a "Solver" interface, like ensemble?
         lb, ub = self.lb, self.ub
         solver = kwds.get('solver', DifferentialEvolutionSolver2)
         npop = kwds.get('npop', None)
-        if npop is not None:
+        if npop is not None or kwds.get('NP', None) is not None:
             solver = solver(len(lb),npop)
         else:
             solver = solver(len(lb))

--- a/examples3/surface.py
+++ b/examples3/surface.py
@@ -302,6 +302,9 @@ class Surface(object): #FIXME: should be subclass of Interpolator (?)
         from mystic.math.interpolate import _to_objective
         _objective = _to_objective(function)
         def objective(x, *args, **kwds):
+            # interpf has f(*x.T); want model(x) so consistent with Learned 
+            import numpy as np
+            x = np.asarray(x).T
             result = _objective(x, *args, **kwds)
             return result.tolist() if hasattr(result, 'tolist') else result
         self.objective = objective
@@ -321,6 +324,9 @@ class Surface(object): #FIXME: should be subclass of Interpolator (?)
         from mystic.math.interpolate import _to_objective
         _objective = _to_objective(self.surrogate)
         def objective(x, *args, **kwds):
+            # interpf has f(*x.T); want model(x) so consistent with Learned 
+            import numpy as np
+            x = np.asarray(x).T
             result = _objective(x, *args, **kwds)
             return result.tolist() if hasattr(result, 'tolist') else result
         objective.__doc__ = self.objective.__doc__

--- a/mystic/math/interpolate.py
+++ b/mystic/math/interpolate.py
@@ -641,8 +641,8 @@ def interpf(x, z, method=None, extrap=False, arrays=False, **kwds):
                 fs = function.__axis__
                 if axis is None:
                     if hasattr(args[0], '__len__'):
-                        return tuple(zt(fi(*args)) for fi in fs)
-                    return tuple(fi(*args) for fi in fs)
+                        return tuple(zt(np.array(list(fi(*args) for fi in fs)).T.tolist()))
+                    return tuple(np.array(list(fi(*args) for fi in fs)).T.tolist())
                 return fs[axis](*args)
             def interpf_ax(i):
                 return interpf(x, z, axis=i, **_kwd)


### PR DESCRIPTION
## Summary
sync InterpModel and LearnedModel ouq_model API
extend to InterpModel and LearnedModel for 2d
add constrained and penalized optML example
add workaround for dict_archive not caching in ouq_models

## Checklist
**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Added relevant documentation that builds in sphinx without error.
- [ ] Added new features that are documented with examples.
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added rationale for any breakage of backwards compatibility.