### PR TITLE
add binned sampler, bounded_sampling with dist

### DIFF
--- a/examples4/MM2_surrogate_diam_batchgrid.py
+++ b/examples4/MM2_surrogate_diam_batchgrid.py
@@ -69,17 +69,10 @@ def optimize(cost,lower,upper,nbins):
   from pathos.pools import ProcessPool as Pool
   random_seed(123)
 
-  # generate arrays of points defining a grid in parameter space
-  grid_dimensions = len(lower)
-  bins = []
-  for i in range(grid_dimensions):
-    step = abs(upper[i] - lower[i])/nbins[i]
-    bins.append( [lower[i] + (j+0.5)*step for j in range(nbins[i])] )
-
   # build a grid of starting points
   from pool_helper import local_optimize
-  from mystic.math.grid import gridpts
-  initial_values = gridpts(bins)
+  from mystic.math.grid import binnedpts
+  initial_values = binnedpts(lower, upper, nbins)
 
   # run optimizer for each grid point
   lb = [lower for i in range(len(initial_values))]

--- a/examples4/MPI2_surrogate_diam_batchgrid.py
+++ b/examples4/MPI2_surrogate_diam_batchgrid.py
@@ -69,17 +69,10 @@ def optimize(cost,lower,upper,nbins):
   from pyina.launchers import Mpi as Pool
   random_seed(123)
 
-  # generate arrays of points defining a grid in parameter space
-  grid_dimensions = len(lower)
-  bins = []
-  for i in range(grid_dimensions):
-    step = abs(upper[i] - lower[i])/nbins[i]
-    bins.append( [lower[i] + (j+0.5)*step for j in range(nbins[i])] )
-
   # build a grid of starting points
   from pool_helper import local_optimize
-  from mystic.math.grid import gridpts
-  initial_values = gridpts(bins)
+  from mystic.math.grid import binnedpts
+  initial_values = binnedpts(lower, upper, nbins)
 
   # run optimizer for each grid point
   lb = [lower for i in range(len(initial_values))]

--- a/examples4/MPI_surrogate_diam_batchgrid.py
+++ b/examples4/MPI_surrogate_diam_batchgrid.py
@@ -6,7 +6,7 @@
 # License: 3-clause BSD.  The full license text is available at:
 #  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
 
-from mystic.math.grid import gridpts
+from mystic.math.grid import binnedpts
 
 #######################################################################
 # scaling and mpi info; also optimizer configuration parameters
@@ -108,15 +108,8 @@ def optimize(cost,lower,upper):
   from pyina.launchers import Mpi as Pool
   random_seed(123)
 
-  # generate arrays of points defining a grid in parameter space
-  grid_dimensions = len(lower)
-  bins = []
-  for i in range(grid_dimensions):
-    step = abs(upper[i] - lower[i])/nbins[i]
-    bins.append( [lower[i] + (j+0.5)*step for j in range(nbins[i])] )
-
   # build a grid of starting points
-  initial_values = gridpts(bins)
+  initial_values = binnedpts(lower, upper, nbins)
 
   # run optimizer for each grid point
   lb = [lower for i in range(len(initial_values))]

--- a/examples4/MSUB_surrogate_diam_batchgrid.py
+++ b/examples4/MSUB_surrogate_diam_batchgrid.py
@@ -6,7 +6,7 @@
 # License: 3-clause BSD.  The full license text is available at:
 #  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
 
-from mystic.math.grid import gridpts
+from mystic.math.grid import binnedpts
 
 #######################################################################
 # scaling and mpi info; also optimizer configuration parameters
@@ -112,15 +112,8 @@ def optimize(cost,lower,upper):
   from pyina.launchers import MoabSlurm as Pool
   random_seed(123)
 
-  # generate arrays of points defining a grid in parameter space
-  grid_dimensions = len(lower)
-  bins = []
-  for i in range(grid_dimensions):
-    step = abs(upper[i] - lower[i])/nbins[i]
-    bins.append( [lower[i] + (j+0.5)*step for j in range(nbins[i])] )
-
   # build a grid of starting points
-  initial_values = gridpts(bins)
+  initial_values = binnedpts(lower, upper, nbins)
 
   # run optimizer for each grid point
   lb = [lower for i in range(len(initial_values))]

--- a/examples4/QSUB2_surrogate_diam_batchgrid.py
+++ b/examples4/QSUB2_surrogate_diam_batchgrid.py
@@ -69,18 +69,11 @@ def optimize(cost,lower,upper,nbins):
   from pyina.launchers import TorqueMpi as Pool
   random_seed(123)
 
-  # generate arrays of points defining a grid in parameter space
-  grid_dimensions = len(lower)
-  bins = []
-  for i in range(grid_dimensions):
-    step = abs(upper[i] - lower[i])/nbins[i]
-    bins.append( [lower[i] + (j+0.5)*step for j in range(nbins[i])] )
-
   # build a grid of starting points
-  from mystic.math.grid import gridpts
+  from mystic.math.grid import binnedpts
   from pool_helper import local_optimize
   from pool_helper import nnodes, queue, timelimit
-  initial_values = gridpts(bins)
+  initial_values = binnedpts(lower, upper, nbins)
 
   # run optimizer for each grid point
   lb = [lower for i in range(len(initial_values))]

--- a/examples4/QSUB_surrogate_diam_batchgrid.py
+++ b/examples4/QSUB_surrogate_diam_batchgrid.py
@@ -6,7 +6,7 @@
 # License: 3-clause BSD.  The full license text is available at:
 #  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
 
-from mystic.math.grid import gridpts
+from mystic.math.grid import binnedpts
 
 #######################################################################
 # scaling and mpi info; also optimizer configuration parameters
@@ -112,15 +112,8 @@ def optimize(cost,lower,upper):
   from pyina.launchers import TorqueMpi as Pool
   random_seed(123)
 
-  # generate arrays of points defining a grid in parameter space
-  grid_dimensions = len(lower)
-  bins = []
-  for i in range(grid_dimensions):
-    step = abs(upper[i] - lower[i])/nbins[i]
-    bins.append( [lower[i] + (j+0.5)*step for j in range(nbins[i])] )
-
   # build a grid of starting points
-  initial_values = gridpts(bins)
+  initial_values = binnedpts(lower, upper, nbins)
 
   # run optimizer for each grid point
   lb = [lower for i in range(len(initial_values))]

--- a/examples4/TEST_surrogate_diam_batchgrid.py
+++ b/examples4/TEST_surrogate_diam_batchgrid.py
@@ -6,8 +6,7 @@
 # License: 3-clause BSD.  The full license text is available at:
 #  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
 
-from mystic.math.grid import gridpts
-
+from mystic.math.grid import binnedpts
 
 #######################################################################
 # scaling and mpi info; also optimizer configuration parameters
@@ -96,15 +95,8 @@ def local_optimize(cost,x0,lb,ub):
 # make a pseudo-global optimizer from a steepest descent optimizer
 #######################################################################
 def optimize(cost,lower,upper):
-  # generate arrays of points defining a grid in parameter space
-  grid_dimensions = len(lower)
-  bins = []
-  for i in range(grid_dimensions):
-    step = abs(upper[i] - lower[i])/nbins[i]
-    bins.append( [lower[i] + (j+0.5)*step for j in range(nbins[i])] )
-
   # build a grid of starting points
-  initial_values = gridpts(bins)
+  initial_values = binnedpts(lower, upper, nbins)
 
   # run optimizer for each grid point
   lb = [lower for i in range(len(initial_values))]

--- a/mystic/ensemble.py
+++ b/mystic/ensemble.py
@@ -59,10 +59,6 @@ All important class members are inherited from AbstractEnsembleSolver.
     def _InitialPoints(self):
         """Generate a grid of starting points for the ensemble of optimizers"""
         nbins = self._nbins or self._npts
-        from numbers import Integral
-        if isinstance(nbins, Integral):
-            from mystic.math.grid import randomly_bin
-            nbins = randomly_bin(nbins, self.nDim, ones=True, exact=True)
         if len(self._strictMax): upper = list(self._strictMax)
         else:
             upper = list(self._defaultMax)
@@ -70,16 +66,9 @@ All important class members are inherited from AbstractEnsembleSolver.
         else:
             lower = list(self._defaultMin)
 
-        # generate arrays of points defining a grid in parameter space
-        grid_dimensions = self.nDim
-        bins = []
-        for i in range(grid_dimensions):
-            step = 1. * abs(upper[i] - lower[i])/nbins[i]
-            bins.append( [lower[i] + (j+0.5)*step for j in range(nbins[i])] )
-
         # build a grid of starting points
-        from mystic.math import gridpts
-        return gridpts(bins, self._dist)
+        from mystic.math import binnedpts
+        return binnedpts(lower, upper, nbins, self._dist)
 
 
 class BuckshotSolver(AbstractEnsembleSolver):
@@ -111,7 +100,7 @@ All important class members are inherited from AbstractEnsembleSolver.
 
         # build a grid of starting points
         from mystic.math import samplepts
-        return samplepts(lower,upper,npts, self._dist)
+        return samplepts(lower, upper, npts, self._dist)
 
 
 class SparsitySolver(AbstractEnsembleSolver):
@@ -146,7 +135,7 @@ All important class members are inherited from AbstractEnsembleSolver.
         from mystic.math import fillpts
         data = self._evalmon._x if self._evalmon else []
         data += self._stepmon._x if self._stepmon else []
-        return fillpts(lower,upper,npts, data, self._rtol, self._dist)
+        return fillpts(lower, upper, npts, data, self._rtol, self._dist)
 
 
 class MixedSolver(AbstractEnsembleSolver):

--- a/mystic/math/__init__.py
+++ b/mystic/math/__init__.py
@@ -26,16 +26,17 @@ These mathematical tools are provided::
 
     polyeval     -- fast evaluation of an n-dimensional polynomial
     poly1d       -- generate a 1d polynomial instance
-    gridpts      -- generate a set of regularly spaced points
-    fillpts      -- generate a set of space-filling points
+    gridpts      -- generate a grid of points given the grid axes
+    binnedpts    -- generate a set of regularly spaced points
     samplepts    -- generate a set of randomly sampled points 
+    fillpts      -- generate a set of space-filling points
     tolerance    -- absolute difference plus relative difference
     almostEqual  -- test if equal within some absolute or relative tolerance
     Distribution -- generate a sampling distribution instance
 """
 # functions and tools
 from .poly import polyeval, poly1d
-from .grid import gridpts, samplepts, fillpts
+from .grid import gridpts, binnedpts, samplepts, fillpts
 from .approx import almostEqual, tolerance
 
 
@@ -45,7 +46,7 @@ from . import discrete as dirac_measure
 from . import distance as paramtrans
 
 __all__ = ['Distribution','polyeval','poly1d','gridpts','samplepts', \
-           'fillpts','almostEqual','tolerance']
+           'binnedpts','fillpts','almostEqual','tolerance']
 
 # distribution object
 class Distribution(object):

--- a/mystic/tests/test_samples.py
+++ b/mystic/tests/test_samples.py
@@ -130,3 +130,15 @@ if pmap:
   p.close()
   p.join()
 
+
+import numpy as np
+_pts = np.clip(pts.T, lb, ub).T
+assert not any((((_pts.T == lb) + (_pts.T == ub)).T).sum(-1))
+
+_pts = ms._bounded_samples(lb, ub, pts.T)
+assert not any((((_pts.T == lb) + (_pts.T == ub)).T).sum(-1))
+
+from mystic.math import Distribution
+dist = Distribution('numpy.random.normal', 0, 1)
+_pts = ms._bounded_samples(lb, ub, pts.T, dist=dist, clip=False)
+assert not any((((_pts.T == lb) + (_pts.T == ub)).T).sum(-1))


### PR DESCRIPTION
## Summary
add binned sampler, providing grid-based sampling taking bounds and number of bins
better bounded sampling for binnedpts and fillpts (similar to samplepts) that stays within bounds when dist is provided

## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Added relevant documentation that builds in sphinx without error.
- [x] Added new features that are documented with examples.
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added rationale for any breakage of backwards compatibility.