### PR TITLE
add errorpts, misfit, fix mixed solver data handling

### DIFF
--- a/examples/misfit_example06.py
+++ b/examples/misfit_example06.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+#
+# Author: Mike McKerns (mmckerns @caltech and @uqfoundation)
+# Copyright (c) 1997-2016 California Institute of Technology.
+# Copyright (c) 2016-2025 The Uncertainty Quantification Foundation.
+# License: 3-clause BSD.  The full license text is available at:
+#  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
+"""
+Example:
+    - Solve 8th-order Chebyshev polynomial coefficients with Powell's method.
+    - Uses MisfitSolver to provide 'pseudo-global' optimization
+    - Plot of fitting to Chebyshev polynomial.
+
+Demonstrates:
+    - standard models
+    - minimal solver interface
+"""
+# the Misfit solver
+from mystic.solvers import MisfitSolver
+
+# Powell's Directonal solver
+from mystic.solvers import PowellDirectionalSolver
+
+# Chebyshev polynomial and cost function
+from mystic.models.poly import chebyshev8, chebyshev8cost
+from mystic.models.poly import chebyshev8coeffs
+
+# if available, use a pathos worker pool
+try:
+    from pathos.pools import ProcessPool as Pool
+   #from pathos.pools import ParallelPool as Pool
+except ImportError:
+    from mystic.pools import SerialPool as Pool
+
+# tools
+from mystic.termination import NormalizedChangeOverGeneration as NCOG
+from mystic.math import poly1d
+from mystic.monitors import VerboseMonitor
+from mystic.tools import getch
+import matplotlib.pyplot as plt
+plt.ion()
+
+# draw the plot
+def plot_exact():
+    plt.title("fitting 8th-order Chebyshev polynomial coefficients")
+    plt.xlabel("x")
+    plt.ylabel("f(x)")
+    import numpy
+    x = numpy.arange(-1.2, 1.2001, 0.01)
+    exact = chebyshev8(x)
+    plt.plot(x,exact,'b-')
+    plt.legend(["Exact"])
+    plt.axis([-1.4,1.4,-2,8])#,'k-')
+    plt.draw()
+    plt.pause(0.001)
+    return
+ 
+# plot the polynomial
+def plot_solution(params,style='y-'):
+    import numpy
+    x = numpy.arange(-1.2, 1.2001, 0.01)
+    f = poly1d(params)
+    y = f(x)
+    plt.plot(x,y,style)
+    plt.legend(["Exact","Fitted"])
+    plt.axis([-1.4,1.4,-2,8])#,'k-')
+    plt.draw()
+    plt.pause(0.001)
+    return
+
+
+if __name__ == '__main__':
+    from pathos.helpers import freeze_support, shutdown
+    freeze_support() # help Windows use multiprocessing
+
+    print("Powell's Method")
+    print("===============")
+
+    # dimensional information
+    from mystic.tools import random_seed
+    random_seed(17)
+    ndim = 9
+    npts = 8
+    mtol = .16
+
+    # draw frame and exact coefficients
+    plot_exact()
+
+    # configure monitor
+    stepmon = VerboseMonitor(1)
+
+    # use misfit-Powell to solve 8th-order Chebyshev coefficients
+    solver = MisfitSolver(ndim, npts, mtol=mtol)
+    solver.SetNestedSolver(PowellDirectionalSolver)
+    solver.SetMapper(Pool().map)
+    solver.SetGenerationMonitor(stepmon)
+    solver.SetStrictRanges(min=[-300]*ndim, max=[300]*ndim)
+    solver.Solve(chebyshev8cost, NCOG(1e-4), disp=1)
+    solution = solver.Solution()
+    shutdown() # help multiprocessing shutdown all workers
+
+    # use pretty print for polynomials
+    print(poly1d(solution))
+
+    # compare solution with actual 8th-order Chebyshev coefficients
+    print("\nActual Coefficients:\n %s\n" % poly1d(chebyshev8coeffs))
+
+    # plot solution versus exact coefficients
+    plot_solution(solution) 
+    getch()
+
+# end of file

--- a/examples3/plot_coords.py
+++ b/examples3/plot_coords.py
@@ -1,0 +1,38 @@
+import numpy as np
+from mystic.tools import random_seed
+random_seed(17)
+from mystic.math import Distribution
+
+size = 10
+lb = [0]*4
+ub = [10]*4
+npts = 20
+std = 1
+dist = Distribution('numpy.random.normal', 0, std)
+X = np.random.random(size=(size,4)) * 10
+y = np.random.random(size=size) * 100
+
+from mpl_toolkits.mplot3d import Axes3D
+import matplotlib.pyplot as plt
+fig = plt.figure()
+ax = fig.add_subplot(111, projection='3d')
+ax.set_xlim3d(0,10)
+ax.set_ylim3d(0,10)
+ax.set_zlim3d(0,10)
+
+from mystic.math.grid import fillpts, samplepts, errorpts
+data = np.array(sorted(errorpts(lb, ub, npts, data=X, error=None, mtol=.05, dist=None)))#dist)))
+#data = np.array(sorted(fillpts(lb, ub, npts, data=X, dist=None)))#dist)))
+#data = np.array(sorted(samplepts(lb, ub, npts, dist=None)))#dist)))
+
+a,b,c,d = data.T
+print(a.min(),a.max())
+print(b.min(),b.max())
+print(c.min(),c.max())
+print(d.min(),d.max())
+
+a0,b0,c0,d0 = X.T
+ax.scatter(a0,b0,c0,c=d0, cmap=plt.hot(), vmin=0,vmax=10, marker='s', edgecolors='k', s=30)
+img = ax.scatter(a,b,c,c=d, cmap=plt.hot(), vmin=0,vmax=10, edgecolors='r', s=30)
+fig.colorbar(img)
+plt.show()

--- a/examples3/xrd_optML4w.py
+++ b/examples3/xrd_optML4w.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+#
+# Author: Mike McKerns (mmckerns @caltech and @uqfoundation)
+# Copyright (c) 2022-2025 The Uncertainty Quantification Foundation.
+# License: 3-clause BSD.  The full license text is available at:
+#  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
+#
+# adapted from XRD example at: https://spotlight.readthedocs.io/
+"""
+optimization of 4-input cost function using online learning of a surrogate
+"""
+import os
+from mystic.samplers import SparsitySampler
+from mystic.monitors import Monitor, LoggingMonitor
+from mystic.solvers import PowellDirectionalSolver
+from mystic.termination import NormalizedChangeOverGeneration as NCOG
+from ouq_models import WrapModel, InterpModel
+from emulators import cost4 as cost, x4 as target, bounds4 as bounds
+#from mystic.cache.archive import file_archive, read as get_db
+
+# prepare truth (i.e. an 'expensive' model)
+nx = 4; ny = None
+#archive = get_db('truth.db', type=file_archive)
+truth = WrapModel('truth', cost, nx=nx, ny=ny, cached=False)#archive)
+
+# remove any prior cached evaluations of truth
+import shutil
+if os.path.exists("truth"): shutil.rmtree("truth")
+if os.path.exists("error.txt"): os.remove("error.txt")
+if os.path.exists("log.txt"): os.remove("log.txt")
+
+try: # parallel maps
+    from pathos.maps import Map
+    from pathos.pools import ProcessPool, ThreadPool, SerialPool
+    pmap = Map(SerialPool) #ProcessPool
+except ImportError:
+    pmap = None
+
+# generate a training dataset by sampling truth
+data = truth.sample(bounds, pts=[2, 1, 1, 1], pmap=pmap)#, archive=archive)
+
+# shutdown mapper
+if pmap is not None:
+    pmap.close(); pmap.join(); pmap.clear()
+
+# create an inexpensive surrogate for truth
+surrogate = InterpModel("surrogate", nx=nx, ny=ny, data=truth, smooth=0.0,
+                        noise=0.0, method="thin_plate", extrap=False)
+
+# iterate until error (of candidate minimum) < 1e-3
+N = 4
+import numpy as np
+import mystic._counter as it
+counter = it.Counter()
+tracker = LoggingMonitor(1, filename='error.txt', label='error')
+evalmon = Monitor() # legacy data for sampler initialization
+#xdata = data.coords # initialize archive data for monitor
+[evalmon(*xi) for xi in zip(data.coords,data.values)]
+from mystic.abstract_solver import AbstractSolver
+from mystic.termination import VTR
+loop = AbstractSolver(nx)
+loop.SetTermination(VTR(1e-3)) #XXX: VTRCOG, TimeLimits, etc?
+loop.SetEvaluationLimits(maxiter=500)
+loop.SetEvaluationMonitor(evalmon)
+loop.SetGenerationMonitor(tracker)
+while not loop.Terminated():
+
+    # fit the surrogate to data in truth database
+    surrogate.fit(data=data)
+    #[evalmon(xi,surrogate(xi)) for xi in xdata] # save latest data to monitor
+
+    # find the first-order critical points of the surrogate
+    mon = Monitor(); mon.prepend(evalmon) # fill with data in db
+    s = SparsitySampler(bounds, lambda x: surrogate(x, axis=None), npts=N,
+                        maxiter=8000, maxfun=1e6, id=counter.count(N),
+                        stepmon=LoggingMonitor(1, label='output'),
+                        solver=PowellDirectionalSolver, evalmon=mon,
+                        termination=NCOG(1e-6, 10))
+    s.sample_until(terminated=all)
+    xdata = [list(i) for i in s._sampler._all_bestSolution]
+    ysurr = s._sampler._all_bestEnergy
+
+    # evaluate truth at the same input as the surrogate critical points
+    ytrue = list(map(truth, xdata))
+    # add most recent candidate extrema to truth database
+    data.load(xdata, ytrue)
+    [evalmon(*xi) for xi in zip(xdata,ytrue)]
+
+    # compute absolute error between truth and surrogate at candidate extrema
+    idx = np.argmin(ytrue)
+    error = abs(np.array(ytrue) - ysurr)
+    print("truth: %s @ %s" % (ytrue[idx], xdata[idx]))
+    print("candidate: %s; error: %s" % (ysurr[idx], error[idx]))
+    print("error ave: %s; error max: %s" % (error.mean(), error.max()))
+    print("evaluations of truth: %s" % len(data))
+
+    # save to tracker if less than current best
+    ysave = error # track error when learning surrogate
+    if len(tracker) and tracker.y[-1] < ysave[idx]:
+        tracker(*tracker[-1])
+    else: tracker(xdata[idx], ysave[idx])
+
+# fit the surrogate to data in truth database
+#surrogate.fit(data=data)
+#[evalmon(xi,surrogate(xi)) for xi in xdata] # save latest data to monitor
+# get the results at the best parameters from the truth database
+xbest = tracker[-1][0]
+#ybest = archive[tuple(xbest)]
+ybest = data[data.coords.index(xbest)].value
+
+# print the best parameters
+print(f"Best solution is {xbest} with Rwp {ybest}")
+print(f"Reference solution: {target}")
+ratios = [x / y for x, y in zip(target, xbest)]
+print(f"Ratios of best to reference solution: {ratios}")

--- a/examples3/xrd_optML4wm.py
+++ b/examples3/xrd_optML4wm.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+#
+# Author: Mike McKerns (mmckerns @caltech and @uqfoundation)
+# Copyright (c) 2022-2025 The Uncertainty Quantification Foundation.
+# License: 3-clause BSD.  The full license text is available at:
+#  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
+#
+# adapted from XRD example at: https://spotlight.readthedocs.io/
+"""
+optimization of 4-input cost function using online learning of a surrogate
+"""
+import os
+from mystic.samplers import MisfitSampler
+from mystic.monitors import Monitor, LoggingMonitor
+from mystic.solvers import PowellDirectionalSolver
+from mystic.termination import NormalizedChangeOverGeneration as NCOG
+from ouq_models import WrapModel, InterpModel
+from emulators import cost4 as cost, x4 as target, bounds4 as bounds
+#from mystic.cache.archive import file_archive, read as get_db
+
+# prepare truth (i.e. an 'expensive' model)
+nx = 4; ny = None
+#archive = get_db('truth.db', type=file_archive)
+truth = WrapModel('truth', cost, nx=nx, ny=ny, cached=False)#archive)
+
+# remove any prior cached evaluations of truth
+import shutil
+if os.path.exists("truth"): shutil.rmtree("truth")
+if os.path.exists("error.txt"): os.remove("error.txt")
+if os.path.exists("log.txt"): os.remove("log.txt")
+
+try: # parallel maps
+    from pathos.maps import Map
+    from pathos.pools import ProcessPool, ThreadPool, SerialPool
+    pmap = Map(SerialPool) #ProcessPool
+except ImportError:
+    pmap = None
+
+# generate a training dataset by sampling truth
+data = truth.sample(bounds, pts=[2, 1, 1, 1], pmap=pmap)#, archive=archive)
+
+# shutdown mapper
+if pmap is not None:
+    pmap.close(); pmap.join(); pmap.clear()
+
+# create an inexpensive surrogate for truth
+surrogate = InterpModel("surrogate", nx=nx, ny=ny, data=truth, smooth=0.0,
+                        noise=0.0, method="thin_plate", extrap=False)
+
+# iterate until error (of candidate minimum) < 1e-3
+N = 4
+import numpy as np
+import mystic._counter as it
+counter = it.Counter()
+tracker = LoggingMonitor(1, filename='error.txt', label='error')
+evalmon = Monitor() # legacy data for sampler initialization
+#xdata = data.coords # initialize archive data for monitor
+[evalmon(*xi) for xi in zip(data.coords,data.values)]
+from mystic.abstract_solver import AbstractSolver
+from mystic.termination import VTR
+loop = AbstractSolver(nx)
+loop.SetTermination(VTR(1e-3)) #XXX: VTRCOG, TimeLimits, etc?
+loop.SetEvaluationLimits(maxiter=500)
+loop.SetEvaluationMonitor(evalmon)
+loop.SetGenerationMonitor(tracker)
+while not loop.Terminated():
+
+    # fit the surrogate to data in truth database
+    surrogate.fit(data=data)
+    #[evalmon(xi,surrogate(xi)) for xi in xdata] # save latest data to monitor
+
+    # find the first-order critical points of the surrogate
+    mon = Monitor(); mon.prepend(evalmon) # fill with data in db
+    s = MisfitSampler(bounds, lambda x: surrogate(x, axis=None), npts=N,
+                      maxiter=8000, maxfun=1e6, id=counter.count(N),
+                      stepmon=LoggingMonitor(1, label='output'),
+                      solver=PowellDirectionalSolver, evalmon=mon,
+                      termination=NCOG(1e-6, 10))
+    s.sample_until(terminated=all)
+    xdata = [list(i) for i in s._sampler._all_bestSolution]
+    ysurr = s._sampler._all_bestEnergy
+
+    # evaluate truth at the same input as the surrogate critical points
+    ytrue = list(map(truth, xdata))
+    # add most recent candidate extrema to truth database
+    data.load(xdata, ytrue)
+    [evalmon(*xi) for xi in zip(xdata,ytrue)]
+
+    # compute absolute error between truth and surrogate at candidate extrema
+    idx = np.argmin(ytrue)
+    error = abs(np.array(ytrue) - ysurr)
+    print("truth: %s @ %s" % (ytrue[idx], xdata[idx]))
+    print("candidate: %s; error: %s" % (ysurr[idx], error[idx]))
+    print("error ave: %s; error max: %s" % (error.mean(), error.max()))
+    print("evaluations of truth: %s" % len(data))
+
+    # save to tracker if less than current best
+    ysave = error # track error when learning surrogate
+    if len(tracker) and tracker.y[-1] < ysave[idx]:
+        tracker(*tracker[-1])
+    else: tracker(xdata[idx], ysave[idx])
+
+# fit the surrogate to data in truth database
+#surrogate.fit(data=data)
+#[evalmon(xi,surrogate(xi)) for xi in xdata] # save latest data to monitor
+# get the results at the best parameters from the truth database
+xbest = tracker[-1][0]
+#ybest = archive[tuple(xbest)]
+ybest = data[data.coords.index(xbest)].value
+
+# print the best parameters
+print(f"Best solution is {xbest} with Rwp {ybest}")
+print(f"Reference solution: {target}")
+ratios = [x / y for x, y in zip(target, xbest)]
+print(f"Ratios of best to reference solution: {ratios}")

--- a/mystic/abstract_ensemble_solver.py
+++ b/mystic/abstract_ensemble_solver.py
@@ -102,7 +102,6 @@ Additional inputs::
     npop     -- size of the trial solution population.      [default = 1]
     nbins    -- tuple of number of bins in each dimension.  [default = [1]*dim]
     npts     -- number of solver instances.                 [default = 1]
-    rtol     -- size of radial tolerance for sparsity.      [default = None]
 
 Important class members::
 
@@ -136,8 +135,6 @@ Important class members::
             pass # nbins = [1]*dim
         else:
             self._npts = reduce(lambda i,j:i*j, nbins) # nbins
-        rtol = kwds['rtol'] if 'rtol' in kwds else None
-        self._rtol            = rtol
         from mystic.solvers import NelderMeadSimplexSolver
         self._solver          = NelderMeadSimplexSolver
         self._bestSolver      = None # 'best' solver (after Solve)
@@ -631,8 +628,9 @@ Notes:
         else: verbose = False
 
         # generate starting points
-        if self._is_new(): iv = self._InitialPoints()
-        else: iv = [None] * len(self._allSolvers)
+        newpts = len(self._allSolvers)
+        if self._is_new(): iv = self._InitialPoints()#[-newpts:]
+        else: iv = [None] * newpts
         op = self._AbstractEnsembleSolver__init_allSolvers()
         vb = [verbose if not s.Terminated() else False for s in self._allSolvers]
         cb = [echo] * len(op) #XXX: remove?
@@ -754,8 +752,9 @@ Notes:
         else: verbose = False
 
         # generate starting points
-        if self._is_new(): iv = self._InitialPoints()
-        else: iv = [None] * len(self._allSolvers)
+        newpts = len(self._allSolvers)
+        if self._is_new(): iv = self._InitialPoints()#[-newpts:]
+        else: iv = [None] * newpts
         op = self._AbstractEnsembleSolver__init_allSolvers()
         vb = [verbose] * len(op)
         cb = [echo] * len(op) #XXX: remove?

--- a/mystic/abstract_sampler.py
+++ b/mystic/abstract_sampler.py
@@ -38,11 +38,11 @@ Args:
         self._kwds = defaultdict(lambda :None)
         self._kwds.update(kwds)
 
-        s = self._init_solver()
         kwd = dict(tight=self._kwds['tightrange'], clip=self._kwds['cliprange'])
-        s.SetStrictRanges(*zip(*bounds), **kwd)
-        #s.SetObjective(memo) #model) #XXX: ExtraArgs: axis ???
-        s.SetObjective(model) #FIXME: ensure cached model
+        s = self._init_solver(**kwd)
+        #s.SetStrictRanges(*zip(*bounds), **kwd)
+        #s.SetObjective(model) #FIXME: ensure cached model
+        ##s.SetObjective(memo) #model) #XXX: ExtraArgs: axis ???
 
         # apply additional kwds
         solver = self._kwds['solver']
@@ -76,10 +76,13 @@ Args:
         return
 
 
-    def _init_solver(self):
+    def _init_solver(self, **kwd):
         """initialize the ensemble solver"""
         from mystic.abstract_ensemble_solver import AbstractEnsembleSolver
-        return AbstractEnsembleSolver(len(self._bounds), npts=self._npts)
+        s = AbstractEnsembleSolver(len(self._bounds), npts=self._npts)
+        s.SetStrictRanges(*zip(*self._bounds), **kwd)
+        s.SetObjective(self._model)
+        return s
 
 
     def _reset_sampler(self):

--- a/mystic/constraints.py
+++ b/mystic/constraints.py
@@ -427,6 +427,10 @@ NOTE: The default solver is 'diffev', with npop=min(40, ndim*5). The default
         from mystic.solvers import SparsitySolver as TheSolver
         solver = TheSolver(ndim, max(8, npts)) #XXX: needs better default?
         ensemble = True
+    elif solver == 'misfit':
+        from mystic.solvers import MisfitSolver as TheSolver
+        solver = TheSolver(ndim, max(8, npts)) #XXX: needs better default?
+        ensemble = True
     
     if termination is None:
         from mystic.termination import ChangeOverGeneration as COG

--- a/mystic/math/__init__.py
+++ b/mystic/math/__init__.py
@@ -30,13 +30,14 @@ These mathematical tools are provided::
     binnedpts    -- generate a set of regularly spaced points
     samplepts    -- generate a set of randomly sampled points 
     fillpts      -- generate a set of space-filling points
+    errorpts     -- generate a set of error-attracted points
     tolerance    -- absolute difference plus relative difference
     almostEqual  -- test if equal within some absolute or relative tolerance
     Distribution -- generate a sampling distribution instance
 """
 # functions and tools
 from .poly import polyeval, poly1d
-from .grid import gridpts, binnedpts, samplepts, fillpts
+from .grid import gridpts, binnedpts, samplepts, fillpts, errorpts
 from .approx import almostEqual, tolerance
 
 
@@ -46,7 +47,7 @@ from . import discrete as dirac_measure
 from . import distance as paramtrans
 
 __all__ = ['Distribution','polyeval','poly1d','gridpts','samplepts', \
-           'binnedpts','fillpts','almostEqual','tolerance']
+           'binnedpts','fillpts','errorpts','almostEqual','tolerance']
 
 # distribution object
 class Distribution(object):

--- a/mystic/math/samples.py
+++ b/mystic/math/samples.py
@@ -39,9 +39,10 @@ Notes: if clip is None, do not clip or resample (may exceed bounds)
     pts = dist((npts,len(lb))) + samples.T # transpose of desired shape
     dist = (dist,)*len(lb)
   if clip is None: return pts.T
+  bad = ((pts == lb) + (pts == ub)).T #NOTE: these points are ok
   pts = np.clip(pts, lb, ub).T
   if clip: return pts  #XXX: returns a numpy.array
-  bad = ((pts.T == lb) + (pts.T == ub)).T
+  bad = ((pts.T == lb) + (pts.T == ub)).T != bad
   new = bad.sum(-1)
   _n, n = 1, 1000
   while any(new):
@@ -49,8 +50,9 @@ Notes: if clip is None, do not clip or resample (may exceed bounds)
       raise RuntimeError('bounds could not be applied in %s iterations' % n)
     for i,inew in enumerate(new): #XXX: slows... but enables iterable dist
       if inew: pts[i][bad[i]] = dist[i](inew) + samples[i][bad[i]]
+    bad = ((pts.T == lb) + (pts.T == ub)).T #NOTE: these points are ok
     pts = np.clip(pts.T, lb, ub).T
-    bad = ((pts.T == lb) + (pts.T == ub)).T
+    bad = ((pts.T == lb) + (pts.T == ub)).T != bad
     new = bad.sum(-1)
     _n += 1
   return pts

--- a/mystic/samplers.py
+++ b/mystic/samplers.py
@@ -7,7 +7,8 @@
 """
 samplers: optimizer-guided directed sampling
 """
-__all__  = ['LatticeSampler','BuckshotSampler','SparsitySampler','MixedSampler']
+__all__  = ['LatticeSampler','BuckshotSampler','SparsitySampler',\
+            'MisfitSampler','MixedSampler']
 
 from mystic.abstract_sampler import AbstractSampler
 
@@ -16,20 +17,26 @@ class LatticeSampler(AbstractSampler):
     """
 optimizer-directed sampling starting at the centers of N grid points
     """
-    def _init_solver(self):
+    def _init_solver(self, **kwd):
         """initialize the ensemble solver"""
         from mystic.ensemble import LatticeSolver
-        return LatticeSolver(len(self._bounds), nbins=self._npts)
+        s = LatticeSolver(len(self._bounds), nbins=self._npts)
+        s.SetStrictRanges(*zip(*self._bounds), **kwd)
+        s.SetObjective(self._model)
+        return s
 
 
 class BuckshotSampler(AbstractSampler):
     """
 optimizer-directed sampling starting at N randomly sampled points
     """
-    def _init_solver(self):
+    def _init_solver(self, **kwd):
         """initialize the ensemble solver"""
         from mystic.ensemble import BuckshotSolver
-        return BuckshotSolver(len(self._bounds), npts=self._npts)
+        s = BuckshotSolver(len(self._bounds), npts=self._npts)
+        s.SetStrictRanges(*zip(*self._bounds), **kwd)
+        s.SetObjective(self._model)
+        return s
 
 
 class SparsitySampler(AbstractSampler):
@@ -41,18 +48,42 @@ optimizer-directed sampling starting at N points sampled in sparse reigons
         super(SparsitySampler, self).__init__(bounds, model, npts, **kwds)
         return
     __init__.__doc__ = AbstractSampler.__init__.__doc__
-    def _init_solver(self):
+    def _init_solver(self, **kwd):
         """initialize the ensemble solver"""
         from mystic.ensemble import SparsitySolver
-        return SparsitySolver(len(self._bounds), npts=self._npts, rtol=self._rtol)
+        s = SparsitySolver(len(self._bounds), npts=self._npts, rtol=self._rtol)
+        s.SetStrictRanges(*zip(*self._bounds), **kwd)
+        s.SetObjective(self._model)
+        return s
+
+
+class MisfitSampler(AbstractSampler):
+    """
+optimizer-directed sampling starting at N points sampled near largest misfit
+    """
+    def __init__(self, bounds, model, npts=None, **kwds):
+        self._mtol = kwds.pop('mtol', None)
+        super(MisfitSampler, self).__init__(bounds, model, npts, **kwds)
+        return
+    __init__.__doc__ = AbstractSampler.__init__.__doc__
+    def _init_solver(self, **kwd):
+        """initialize the ensemble solver"""
+        from mystic.ensemble import MisfitSolver
+        s = MisfitSolver(len(self._bounds), npts=self._npts, mtol=self._mtol, func=self._model) #FIXME: TEST (mon?)
+        s.SetStrictRanges(*zip(*self._bounds), **kwd)
+        s.SetObjective(self._model)
+        return s
 
 
 class MixedSampler(AbstractSampler):
     """
 optimizer-directed sampling using N points from a mixture of ensemble solvers
     """
-    def _init_solver(self):
+    def _init_solver(self, **kwd):
         """initialize the ensemble solver"""
         from mystic.ensemble import MixedSolver
-        return MixedSolver(len(self._bounds), samp=self._npts)
+        s = MixedSolver(len(self._bounds), samp=self._npts)
+        s.SetStrictRanges(*zip(*self._bounds), **kwd)
+        s.SetObjective(self._model)
+        return s
 

--- a/mystic/solvers.py
+++ b/mystic/solvers.py
@@ -21,9 +21,10 @@ and in each derived optimizer.  Mystic's optimizers are::
     DifferentialEvolutionSolver  -- Differential Evolution algorithm
     DifferentialEvolutionSolver2 -- Price & Storn's Differential Evolution
     ** Pseudo-Global Optimizers **
-    SparsitySolver               -- N Solvers sampled where point density is low
     BuckshotSolver               -- Uniform Random Distribution of N Solvers
     LatticeSolver                -- Distribution of N Solvers on a Regular Grid
+    SparsitySolver               -- N Solvers Sampled where Point Density is Low
+    MisfitSolver                 -- N Solvers Sampled where Model Misfit is High
     MixedSolver                  -- Mixture of N Pseudo-Global Optimizers
     ** Local-Search Optimizers **
     NelderMeadSimplexSolver      -- Nelder-Mead Simplex algorithm
@@ -43,9 +44,10 @@ are provided::
     diffev      -- DifferentialEvolutionSolver
     diffev2     -- DifferentialEvolutionSolver2
     ** Pseudo-Global Optimizers **
-    sparsity    -- SparsitySolver
     buckshot    -- BuckshotSolver
     lattice     -- LatticeSolver
+    sparsity    -- SparsitySolver
+    misfit      -- MisfitSolver
     ** Local-Search Optimizers **
     fmin        -- NelderMeadSimplexSolver
     fmin_powell -- PowellDirectionalSolver
@@ -71,11 +73,12 @@ from mystic.differential_evolution import DifferentialEvolutionSolver2
 from mystic.differential_evolution import diffev, diffev2
 
 # pseudo-global optimizers
-from mystic.ensemble import SparsitySolver
 from mystic.ensemble import BuckshotSolver
 from mystic.ensemble import LatticeSolver
+from mystic.ensemble import SparsitySolver
+from mystic.ensemble import MisfitSolver
 from mystic.ensemble import MixedSolver
-from mystic.ensemble import sparsity, buckshot, lattice
+from mystic.ensemble import buckshot, lattice, sparsity, misfit
 
 # local-search optimizers
 from mystic.scipy_optimize import NelderMeadSimplexSolver

--- a/mystic/tests/test_boundsconstrained.py
+++ b/mystic/tests/test_boundsconstrained.py
@@ -14,7 +14,7 @@ from mystic.solvers import PowellDirectionalSolver, NelderMeadSimplexSolver, \
                            DifferentialEvolutionSolver, \
                            DifferentialEvolutionSolver2, \
                            LatticeSolver, BuckshotSolver, SparsitySolver, \
-                           MixedSolver
+                           MisfitSolver, MixedSolver
 
 almostEqual = my.math.almostEqual
 rosen = mm.rosen
@@ -71,6 +71,9 @@ test_constrained(DifferentialEvolutionSolver2, tight=None, clip=None)
 #test_constrained(SparsitySolver, tight=True, clip=None) #npts=8?
 #test_constrained(SparsitySolver, tight=True, clip=True)
 #test_constrained(SparsitySolver, tight=None, clip=None)
+#test_constrained(MisfitSolver, tight=True, clip=None) #npts=8?
+#test_constrained(MisfitSolver, tight=True, clip=True)
+#test_constrained(MisfitSolver, tight=None, clip=None)
 #test_constrained(MixedSolver, tight=True, clip=None) #samp=8?
 #test_constrained(MixedSolver, tight=True, clip=True)
 #test_constrained(MixedSolver, tight=None, clip=None)

--- a/mystic/tests/test_ensemble.py
+++ b/mystic/tests/test_ensemble.py
@@ -1,0 +1,37 @@
+import numpy as np
+from mystic.solvers import *
+from mystic.models import rosen
+from mystic.monitors import Monitor, VerboseMonitor
+from mystic.tools import random_seed
+ndim = 3
+npts = 3
+ini = 2
+
+def get_xy(solver):
+    mon = init_data()
+    solver.SetEvaluationMonitor(mon)
+    solver.SetStrictRanges(min=[0]*ndim, max=[10]*ndim)
+    solver.SetObjective(rosen)
+    solver.Step()
+    solver.Solution()
+    x = [getattr(i, '_evalmon', Monitor())._x[ini:][0] for i in solver._allSolvers]
+    y = [getattr(i, '_evalmon', Monitor())._y[ini:][0] for i in solver._allSolvers]
+    return x,y
+
+def init_data():
+    # add some intital data
+    random_seed(123)
+    mon = Monitor()
+    mon._x = (np.random.random(size=(ini,ndim))*10).tolist()
+    mon._y = (list(map(rosen, mon._x)) + np.random.normal(0,.05, size=ini)).tolist()
+    return mon
+
+solvers = ['MisfitSolver', 'SparsitySolver', 'BuckshotSolver', 'LatticeSolver']
+for solver in solvers:
+    samp = {solver: (npts,)}
+    solver = eval(solver)(ndim, *samp[solver])
+    x,y = get_xy(solver)
+    solver = MixedSolver(ndim, samp)
+    xm,ym = get_xy(solver)
+    assert x == xm
+    assert y == ym

--- a/mystic/tests/test_samplers.py
+++ b/mystic/tests/test_samplers.py
@@ -7,7 +7,8 @@
 
 from mystic.solvers import PowellDirectionalSolver
 from mystic.termination import NormalizedChangeOverGeneration as NCOG
-from mystic.samplers import SparsitySampler, BuckshotSampler, LatticeSampler, MixedSampler
+from mystic.samplers import (SparsitySampler, BuckshotSampler, LatticeSampler,
+                             MisfitSampler, MixedSampler)
 from mystic.models import sphere as model
 from mystic.math import almostEqual
 x0 = [0,0,0,0]
@@ -16,7 +17,8 @@ bounds = [(-1,1)]*4
 N = 8
 
 
-for sampler in (SparsitySampler, BuckshotSampler, LatticeSampler, MixedSampler):
+for sampler in (SparsitySampler, BuckshotSampler, LatticeSampler,
+                MisfitSampler, MixedSampler):
     s = sampler(bounds, model, npts=N, id=0, maxiter=8000, maxfun=1e6,
                 solver=PowellDirectionalSolver, termination=NCOG(1e-6, 10))
     s.sample_until(terminated=all)


### PR DESCRIPTION
## Summary
add:
 - `errorpts` grid method to sample "near" projected maximum error.
 - `misfit` solver and sampler, to use `errorpts` grid sampling
 - tests for `misfit` sampler and solver

fix data handling in `mixed` solver, so mixed sampler matches use of individual sampler


## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Added relevant documentation that builds in sphinx without error.
- [x] Added new features that are documented with examples.
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [ ] Added rationale for any breakage of backwards compatibility.
