### PR TITLE
rename misfit to residual and add args for cache.function.read

### DIFF
--- a/examples/residual_example06.py
+++ b/examples/residual_example06.py
@@ -8,15 +8,15 @@
 """
 Example:
     - Solve 8th-order Chebyshev polynomial coefficients with Powell's method.
-    - Uses MisfitSolver to provide 'pseudo-global' optimization
+    - Uses ResidualSolver to provide 'pseudo-global' optimization
     - Plot of fitting to Chebyshev polynomial.
 
 Demonstrates:
     - standard models
     - minimal solver interface
 """
-# the Misfit solver
-from mystic.solvers import MisfitSolver
+# the Residual solver
+from mystic.solvers import ResidualSolver
 
 # Powell's Directonal solver
 from mystic.solvers import PowellDirectionalSolver
@@ -89,8 +89,8 @@ if __name__ == '__main__':
     # configure monitor
     stepmon = VerboseMonitor(1)
 
-    # use misfit-Powell to solve 8th-order Chebyshev coefficients
-    solver = MisfitSolver(ndim, npts, mtol=mtol)
+    # use residual-Powell to solve 8th-order Chebyshev coefficients
+    solver = ResidualSolver(ndim, npts, mtol=mtol)
     solver.SetNestedSolver(PowellDirectionalSolver)
     solver.SetMapper(Pool().map)
     solver.SetGenerationMonitor(stepmon)

--- a/examples3/plot_grid.py
+++ b/examples3/plot_grid.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env python
+#
+# Author: Mike McKerns (mmckerns @caltech and @uqfoundation)
+# Copyright (c) 2025 The Uncertainty Quantification Foundation.
+# License: 3-clause BSD.  The full license text is available at:
+#  - https://github.com/uqfoundation/mystic/blob/master/LICENSE
 import numpy as np
 from mystic.tools import random_seed
 random_seed(17)

--- a/examples3/xrd_optML3.py
+++ b/examples3/xrd_optML3.py
@@ -20,7 +20,7 @@ from emulators import cost3 as cost, x3 as target, bounds3 as bounds
 # prepare truth (i.e. an 'expensive' model)
 nx = 3; ny = None
 archive = get_db('truth.db', type=file_archive)
-truth = WrapModel("truth", cost, nx=nx, ny=ny, cached=archive)
+truth = WrapModel("truth", cost, nx=nx, ny=ny, rnd=False, cached=archive)
 
 # remove any prior cached evaluations of truth
 archive.clear(); archive.sync(clear=True)
@@ -43,7 +43,7 @@ if pmap is not None:
 
 # create an inexpensive surrogate for truth
 surrogate = InterpModel("surrogate", nx=nx, ny=ny, data=truth, smooth=0.0,
-                        noise=0.0, method="thin_plate", extrap=False)
+                        noise=0.0, method="thin_plate", rnd=False, extrap=False)
 
 # iterate until error (of candidate minimum) < 1e-3
 tracker = LoggingMonitor(1, filename='error.txt', label='error')

--- a/examples3/xrd_optML3DT.py
+++ b/examples3/xrd_optML3DT.py
@@ -20,7 +20,7 @@ from emulators import cost3 as cost, x3 as target, bounds3 as bounds
 # prepare truth (i.e. an 'expensive' model)
 nx = 3; ny = None
 archive = get_db('truth.db', type=file_archive)
-truth = WrapModel("truth", cost, nx=nx, ny=ny, cached=archive)
+truth = WrapModel("truth", cost, nx=nx, ny=ny, rnd=False, cached=archive)
 
 # remove any prior cached evaluations of truth
 archive.clear(); archive.sync(clear=True)
@@ -57,7 +57,7 @@ kwds = dict(estimator=DTRegressor(**args), transform=None)
 # iteratively improve estimator
 dtr = Estimator(**kwds)
 best = improve_score(dtr, MLData(data.coords, data.coords, data.values, data.values), tries=10, verbose=True)
-mlkw = dict(estimator=best.estimator, transform=best.transform)
+mlkw = dict(estimator=best.estimator, transform=best.transform, rnd=False)
 surrogate = LearnedModel('surrogate', nx=nx, ny=ny, data=truth, **mlkw)
 
 # iterate until error (of candidate minimum) < 1e-3

--- a/examples3/xrd_optML3GP.py
+++ b/examples3/xrd_optML3GP.py
@@ -20,7 +20,7 @@ from emulators import cost3 as cost, x3 as target, bounds3 as bounds
 # prepare truth (i.e. an 'expensive' model)
 nx = 3; ny = None
 archive = get_db('truth.db', type=file_archive)
-truth = WrapModel("truth", cost, nx=nx, ny=ny, cached=archive)
+truth = WrapModel("truth", cost, nx=nx, ny=ny, rnd=False, cached=archive)
 
 # remove any prior cached evaluations of truth
 archive.clear(); archive.sync(clear=True)
@@ -55,7 +55,7 @@ kwds = dict(estimator=GPRegressor(**args), transform=StandardScaler())
 # iteratively improve estimator
 gpr = Estimator(**kwds)
 best = improve_score(gpr, MLData(data.coords, data.coords, data.values, data.values), tries=10, verbose=True)
-mlkw = dict(estimator=best.estimator, transform=best.transform)
+mlkw = dict(estimator=best.estimator, transform=best.transform, rnd=False)
 surrogate = LearnedModel('surrogate', nx=nx, ny=ny, data=truth, **mlkw)
 
 # iterate until error (of candidate minimum) < 1e-3

--- a/examples3/xrd_optML3NN.py
+++ b/examples3/xrd_optML3NN.py
@@ -20,7 +20,7 @@ from emulators import cost3 as cost, x3 as target, bounds3 as bounds
 # prepare truth (i.e. an 'expensive' model)
 nx = 3; ny = None
 archive = get_db('truth.db', type=file_archive)
-truth = WrapModel("truth", cost, nx=nx, ny=ny, cached=archive)
+truth = WrapModel("truth", cost, nx=nx, ny=ny, rnd=False, cached=archive)
 
 # remove any prior cached evaluations of truth
 archive.clear(); archive.sync(clear=True)
@@ -50,7 +50,7 @@ kwds = dict(estimator=MLPRegressor(**args), transform=StandardScaler())
 # iteratively improve estimator
 mlp = Estimator(**kwds)
 best = improve_score(mlp, MLData(data.coords, data.coords, data.values, data.values), tries=10, verbose=True)
-mlkw = dict(estimator=best.estimator, transform=best.transform)
+mlkw = dict(estimator=best.estimator, transform=best.transform, rnd=False)
 surrogate = LearnedModel('surrogate', nx=nx, ny=ny, data=truth, **mlkw)
 
 # iterate until error (of candidate minimum) < 1e-3

--- a/examples3/xrd_optML3NN_skorch.py
+++ b/examples3/xrd_optML3NN_skorch.py
@@ -20,7 +20,7 @@ from emulators import cost3 as cost, x3 as target, bounds3 as bounds
 # prepare truth (i.e. an 'expensive' model)
 nx = 3; ny = None
 archive = get_db('truth.db', type=file_archive)
-truth = WrapModel("truth", cost, nx=nx, ny=ny, cached=archive)
+truth = WrapModel("truth", cost, nx=nx, ny=ny, rnd=False, cached=archive)
 
 # remove any prior cached evaluations of truth
 archive.clear(); archive.sync(clear=True)
@@ -61,7 +61,7 @@ kwds = dict(estimator=estimator, transform=StandardScaler())
 # iteratively improve estimator
 mlp = Estimator(**kwds)
 best = improve_score(mlp, MLData(data.coords, data.coords, data.values, data.values), tries=10, verbose=True)
-mlkw = dict(estimator=best.estimator, transform=best.transform)
+mlkw = dict(estimator=best.estimator, transform=best.transform, rnd=False)
 surrogate = LearnedModel('surrogate', nx=nx, ny=ny, data=truth, **mlkw)
 
 # iterate until error (of candidate minimum) < 1e-3

--- a/examples3/xrd_optML3c.py
+++ b/examples3/xrd_optML3c.py
@@ -38,7 +38,7 @@ constraint = generate_constraint(generate_solvers(simplify(equations)))
 # prepare truth (i.e. an 'expensive' model)
 nx = 3; ny = None
 archive = get_db('truth.db', type=file_archive)
-truth = WrapModel("truth", cost, nx=nx, ny=ny, cached=archive)
+truth = WrapModel("truth", cost, nx=nx, ny=ny, rnd=False, cached=archive)
 
 # remove any prior cached evaluations of truth
 archive.clear(); archive.sync(clear=True)
@@ -62,7 +62,7 @@ if pmap is not None:
 
 # create an inexpensive surrogate for truth
 surrogate = InterpModel("surrogate", nx=nx, ny=ny, data=truth, smooth=0.0,
-                        noise=0.0, method="thin_plate", extrap=False)
+                        noise=0.0, method="thin_plate", rnd=False, extrap=False)
 
 # iterate until error (of candidate minimum) < 1e-3
 tracker = LoggingMonitor(1, filename='error.txt', label='error')

--- a/examples3/xrd_optML4.py
+++ b/examples3/xrd_optML4.py
@@ -20,7 +20,7 @@ from emulators import cost4 as cost, x4 as target, bounds4 as bounds
 # prepare truth (i.e. an 'expensive' model)
 nx = 4; ny = None
 archive = get_db('truth.db', type=file_archive)
-truth = WrapModel("truth", cost, nx=nx, ny=ny, cached=archive)
+truth = WrapModel("truth", cost, nx=nx, ny=ny, rnd=False, cached=archive)
 
 # remove any prior cached evaluations of truth
 archive.clear(); archive.sync(clear=True)
@@ -43,7 +43,7 @@ if pmap is not None:
 
 # create an inexpensive surrogate for truth
 surrogate = InterpModel("surrogate", nx=nx, ny=ny, data=truth, smooth=0.0,
-                        noise=0.0, method="thin_plate", extrap=False)
+                        noise=0.0, method="thin_plate", rnd=False, extrap=False)
 
 # iterate until error (of candidate minimum) < 1e-3
 import mystic._counter as it

--- a/examples3/xrd_optML4s.py
+++ b/examples3/xrd_optML4s.py
@@ -22,7 +22,7 @@ from emulators import cost4 as cost, x4 as target, bounds4 as bounds
 # prepare truth (i.e. an 'expensive' model)
 nx = 4; ny = None
 archive = get_db('truth.db', type=file_archive)
-truth = WrapModel("truth", cost, nx=nx, ny=ny, cached=archive)
+truth = WrapModel("truth", cost, nx=nx, ny=ny, rnd=False, cached=archive)
 
 # remove any prior cached evaluations of truth
 archive.clear(); archive.sync(clear=True)
@@ -49,7 +49,7 @@ if pmap is not None:
 
 # create an inexpensive surrogate for truth
 surrogate = InterpModel("surrogate", nx=nx, ny=ny, data=truth, smooth=0.0,
-                        noise=0.0, method="thin_plate", extrap=False)
+                        noise=0.0, method="thin_plate", rnd=False, extrap=False)
 
 # iterate until error (of candidate minimum) < 1e-3
 N = 4

--- a/examples3/xrd_optML4v.py
+++ b/examples3/xrd_optML4v.py
@@ -21,7 +21,7 @@ from emulators import cost4 as cost, x4 as target, bounds4 as bounds
 # prepare truth (i.e. an 'expensive' model)
 nx = 4; ny = None
 #archive = get_db('truth.db', type=file_archive)
-truth = WrapModel('truth', cost, nx=nx, ny=ny, cached=False)#archive)
+truth = WrapModel('truth', cost, nx=nx, ny=ny, rnd=False, cached=False)#archive)
 
 # remove any prior cached evaluations of truth
 import shutil
@@ -45,7 +45,7 @@ if pmap is not None:
 
 # create an inexpensive surrogate for truth
 surrogate = InterpModel("surrogate", nx=nx, ny=ny, data=truth, smooth=0.0,
-                        noise=0.0, method="thin_plate", extrap=False)
+                        noise=0.0, method="thin_plate", rnd=False, extrap=False)
 
 # iterate until error (of candidate minimum) < 1e-3
 N = 4

--- a/examples3/xrd_optML4vy.py
+++ b/examples3/xrd_optML4vy.py
@@ -21,7 +21,7 @@ from emulators import cost4 as cost, x4 as target, bounds4 as bounds
 # prepare truth (i.e. an 'expensive' model)
 nx = 4; ny = None
 #archive = get_db('truth.db', type=file_archive)
-truth = WrapModel('truth', cost, nx=nx, ny=ny, cached=False)#archive)
+truth = WrapModel('truth', cost, nx=nx, ny=ny, rnd=False, cached=False)#archive)
 
 # remove any prior cached evaluations of truth
 import shutil
@@ -45,7 +45,7 @@ if pmap is not None:
 
 # create an inexpensive surrogate for truth
 surrogate = InterpModel("surrogate", nx=nx, ny=ny, data=truth, smooth=0.0,
-                        noise=0.0, method="thin_plate", extrap=False)
+                        noise=0.0, method="thin_plate", rnd=False, extrap=False)
 
 # iterate until change in truth <= 1e-3 for 5 iterations
 N = 4

--- a/examples3/xrd_optML4wm.py
+++ b/examples3/xrd_optML4wm.py
@@ -10,7 +10,7 @@
 optimization of 4-input cost function using online learning of a surrogate
 """
 import os
-from mystic.samplers import MisfitSampler
+from mystic.samplers import ResidualSampler
 from mystic.monitors import Monitor, LoggingMonitor
 from mystic.solvers import PowellDirectionalSolver
 from mystic.termination import NormalizedChangeOverGeneration as NCOG
@@ -21,13 +21,14 @@ from emulators import cost4 as cost, x4 as target, bounds4 as bounds
 # prepare truth (i.e. an 'expensive' model)
 nx = 4; ny = None
 #archive = get_db('truth.db', type=file_archive)
-truth = WrapModel('truth', cost, nx=nx, ny=ny, cached=False)#archive)
+truth = WrapModel('truth', cost, nx=nx, ny=ny, rnd=False, cached=False)#archive)
 
 # remove any prior cached evaluations of truth
 import shutil
 if os.path.exists("truth"): shutil.rmtree("truth")
 if os.path.exists("error.txt"): os.remove("error.txt")
 if os.path.exists("log.txt"): os.remove("log.txt")
+if os.path.exists("function"): shutil.rmtree("function")
 
 try: # parallel maps
     from pathos.maps import Map
@@ -45,7 +46,7 @@ if pmap is not None:
 
 # create an inexpensive surrogate for truth
 surrogate = InterpModel("surrogate", nx=nx, ny=ny, data=truth, smooth=0.0,
-                        noise=0.0, method="thin_plate", extrap=False)
+                        noise=0.0, method="thin_plate", rnd=False, extrap=False)
 
 # iterate until error (of candidate minimum) < 1e-3
 N = 4
@@ -63,20 +64,25 @@ loop.SetTermination(VTR(1e-3)) #XXX: VTRCOG, TimeLimits, etc?
 loop.SetEvaluationLimits(maxiter=500)
 loop.SetEvaluationMonitor(evalmon)
 loop.SetGenerationMonitor(tracker)
+from mystic.cache.function import write as surrogatedb
 while not loop.Terminated():
 
     # fit the surrogate to data in truth database
     surrogate.fit(data=data)
     #[evalmon(xi,surrogate(xi)) for xi in xdata] # save latest data to monitor
+    # save surrogate to archive
+    surrogatedb(surrogate, 'function')
 
     # find the first-order critical points of the surrogate
     mon = Monitor(); mon.prepend(evalmon) # fill with data in db
-    s = MisfitSampler(bounds, lambda x: surrogate(x, axis=None), npts=N,
-                      maxiter=8000, maxfun=1e6, id=counter.count(N),
-                      stepmon=LoggingMonitor(1, label='output'),
-                      solver=PowellDirectionalSolver, evalmon=mon,
-                      termination=NCOG(1e-6, 10))
+    s = ResidualSampler(bounds, lambda x: surrogate(x, axis=None), npts=N,
+                        maxiter=8000, maxfun=1e6, id=counter.count(N),
+                        stepmon=LoggingMonitor(1, label='output'),
+                        solver=PowellDirectionalSolver, evalmon=mon,
+                        termination=NCOG(1e-6, 10))
     s.sample_until(terminated=all)
+
+    # get surrogate at critical points
     xdata = [list(i) for i in s._sampler._all_bestSolution]
     ysurr = s._sampler._all_bestEnergy
 

--- a/examples3/xrd_optML4x.py
+++ b/examples3/xrd_optML4x.py
@@ -19,7 +19,7 @@ from emulators import cost4 as cost, x4 as target, bounds4 as bounds
 # prepare truth (i.e. an 'expensive' model)
 nx = 4; ny = None
 #archive = get_db('truth.db', type=file_archive)
-truth = WrapModel('truth', cost, nx=nx, ny=ny, cached=False)#archive)
+truth = WrapModel('truth', cost, nx=nx, ny=ny, rnd=False, cached=False)#archive)
 
 # remove any prior cached evaluations of truth
 import shutil
@@ -43,7 +43,7 @@ if pmap is not None:
 
 # create an inexpensive surrogate for truth
 surrogate = InterpModel("surrogate", nx=nx, ny=ny, data=truth, smooth=0.0,
-                        noise=0.0, method="thin_plate", extrap=False)
+                        noise=0.0, method="thin_plate", rnd=False, extrap=False)
 
 # iterate until error (of candidate minimum) < 1e-3
 N = 4

--- a/examples3/xrd_optML4xs.py
+++ b/examples3/xrd_optML4xs.py
@@ -19,7 +19,7 @@ from mystic.cache.archive import file_archive, read as get_db
 # prepare truth (i.e. an 'expensive' model)
 nx = 4; ny = None
 #archive = get_db('truth.db', type=file_archive)
-truth = WrapModel('truth', cost, nx=nx, ny=ny, cached=False)#archive)
+truth = WrapModel('truth', cost, nx=nx, ny=ny, rnd=False, cached=False)#archive)
 
 # remove any prior cached evaluations of truth
 import shutil
@@ -46,7 +46,7 @@ if pmap is not None:
 
 # create an inexpensive surrogate for truth
 surrogate = InterpModel("surrogate", nx=nx, ny=ny, data=truth, smooth=0.0,
-                        noise=0.0, method="thin_plate", extrap=False)
+                        noise=0.0, method="thin_plate", rnd=False, extrap=False)
 
 # iterate until error (of candidate minimum) < 1e-3
 N = 4

--- a/examples3/xrd_optML4y.py
+++ b/examples3/xrd_optML4y.py
@@ -20,7 +20,7 @@ from emulators import cost4 as cost, x4 as target, bounds4 as bounds
 # prepare truth (i.e. an 'expensive' model)
 nx = 4; ny = None
 archive = get_db('truth.db', type=file_archive)
-truth = WrapModel("truth", cost, nx=nx, ny=ny, cached=archive)
+truth = WrapModel("truth", cost, nx=nx, ny=ny, rnd=False, cached=archive)
 
 # remove any prior cached evaluations of truth
 archive.clear(); archive.sync(clear=True)
@@ -43,7 +43,7 @@ if pmap is not None:
 
 # create an inexpensive surrogate for truth
 surrogate = InterpModel("surrogate", nx=nx, ny=ny, data=truth, smooth=0.0,
-                        noise=0.0, method="thin_plate", extrap=False)
+                        noise=0.0, method="thin_plate", rnd=False, extrap=False)
 
 # iterate until change in truth <= 1e-3 for 5 iterations
 import mystic._counter as it

--- a/mystic/cache/function.py
+++ b/mystic/cache/function.py
@@ -29,11 +29,14 @@ def write(function, archives):
         [rb._write_func(a, f, {}) for a,f in zip(archives,function.__axis__)]
 
 
-def read(archives): # method?
+def read(archives, keymap=None, type=None, n=0): # method?
     """read stored functions from the list of dbs
 
     Args:
         archives (list[string]): list of names of function archives
+        keymap (klepto.keymap): keymap used for key encoding
+        type (klepto.archive): type of klepto archive
+        n (int): db entry in reverse order (i.e. most recent is ``0``)
 
     Returns:
         a klepto.archive instance
@@ -43,11 +46,12 @@ def read(archives): # method?
         corresponding to the desired axis. If a db is empty, returns ``None``
         for the empty db. Also, a klepto.archive instance can be provided
         instead of the ``name`` of the db.
-    """
+    """ #XXX: n as tuple for each axis?
+    from builtins import type as _type
     if isinstance(archives, (str, (u'').__class__)):
         archives = db(archives)
-    if type(archives).__module__.startswith('klepto.'):
-        f = rb.read_func(db(archives))
+    if _type(archives).__module__.startswith('klepto.'):
+        f = rb.read_func(db(archives), keymap=keymap, type=type, n=n)
         if f is None:
             return f
         f = f[0]
@@ -56,6 +60,7 @@ def read(archives): # method?
         return f
     from mystic.math.interpolate import interpf
     f = interpf([[1,2],[2,3]],[[1,2],[2,3]],method='thin_plate')
-    f.__axis__[:] = [(i if i is None else i[0]) for i in map(rb.read_func, map(db, archives))]
+    read_func = lambda x: rb.read_func(x, keymap=keymap, type=type, n=n)
+    f.__axis__[:] = [(i if i is None else i[0]) for i in map(read_func, map(db, archives))]
     return f
 

--- a/mystic/constraints.py
+++ b/mystic/constraints.py
@@ -427,8 +427,8 @@ NOTE: The default solver is 'diffev', with npop=min(40, ndim*5). The default
         from mystic.solvers import SparsitySolver as TheSolver
         solver = TheSolver(ndim, max(8, npts)) #XXX: needs better default?
         ensemble = True
-    elif solver == 'misfit':
-        from mystic.solvers import MisfitSolver as TheSolver
+    elif solver == 'residual':
+        from mystic.solvers import ResidualSolver as TheSolver
         solver = TheSolver(ndim, max(8, npts)) #XXX: needs better default?
         ensemble = True
     

--- a/mystic/ensemble.py
+++ b/mystic/ensemble.py
@@ -18,7 +18,7 @@ The set of solvers built on mystic's AbstractEnsembleSolver are::
    LatticeSolver -- start from center of N grid points
    BuckshotSolver -- start from N random points in parameter space
    SparsitySolver -- start from N points sampled in sparse regions of space
-   MisfitSolver -- start from N points near the largest misfit to legacy data
+   ResidualSolver -- start from N points near the largest misfit to legacy data
    MixedSolver -- start from N points using a mixture of ensemble solvers
 
 parallel mapped optimization starting from N points sampled near largest error
@@ -33,8 +33,8 @@ or an example of using LatticeSolver.
 All solvers included in this module provide the standard signal handling.
 For more information, see `mystic.mystic.abstract_solver`.
 """
-__all__ = ['LatticeSolver','BuckshotSolver','SparsitySolver','MisfitSolver', \
-           'MixedSolver', 'lattice','buckshot','sparsity','misfit']
+__all__ = ['LatticeSolver','BuckshotSolver','SparsitySolver','ResidualSolver', \
+           'MixedSolver', 'lattice','buckshot','sparsity','residual']
 
 from mystic.tools import unpair
 
@@ -145,7 +145,7 @@ All important class members are inherited from AbstractEnsembleSolver.
         return fillpts(lower, upper, npts, data, self._rtol, self._dist)
 
 
-class MisfitSolver(AbstractEnsembleSolver):
+class ResidualSolver(AbstractEnsembleSolver):
     """
 parallel mapped optimization starting from N points sampled near largest misfit
     """
@@ -159,7 +159,7 @@ Takes four initial inputs:
 
 All important class members are inherited from AbstractEnsembleSolver.
         """
-        super(MisfitSolver, self).__init__(dim, npts=npts)
+        super(ResidualSolver, self).__init__(dim, npts=npts)
         from mystic.termination import NormalizedChangeOverGeneration
         convergence_tol = 1e-4
         self._termination = NormalizedChangeOverGeneration(convergence_tol)
@@ -651,11 +651,11 @@ Notes:
     return retlist
 
 
-def misfit(cost,ndim,npts=8,args=(),bounds=None,ftol=1e-4,maxiter=None, \
-           maxfun=None,full_output=0,disp=1,retall=0,callback=None,**kwds):
-    """Minimize a function using the misfit ensemble solver.
+def residual(cost,ndim,npts=8,args=(),bounds=None,ftol=1e-4,maxiter=None, \
+             maxfun=None,full_output=0,disp=1,retall=0,callback=None,**kwds):
+    """Minimize a function using the residual ensemble solver.
 
-Uses a misfit ensemble algorithm to find the minimum of a function of one or
+Uses a residual ensemble algorithm to find the minimum of a function of one or
 more variables. Mimics the ``scipy.optimize.fmin`` interface. Starts *npts*
 solver instances near the maximum of an interpolated error surface, where
 error is the absolute difference between a given function and existing points.
@@ -728,7 +728,7 @@ Notes:
         termination = VTRChangeOverGeneration(ftol)
     mtol = kwds['mtol'] if 'mtol' in kwds else None #NOTE: 'data' set w/monitors
 
-    solver = MisfitSolver(ndim,npts,mtol)
+    solver = ResidualSolver(ndim,npts,mtol)
     solver.SetNestedSolver(_solver) #XXX: skip settings for configured solver?
     solver.SetEvaluationLimits(maxiter,maxfun)
     solver.SetEvaluationMonitor(evalmon)

--- a/mystic/math/grid.py
+++ b/mystic/math/grid.py
@@ -171,8 +171,9 @@ Notes: if clip is None, do not clip or resample (may exceed bounds)
     """ #NOTE: error cannot be multi-valued
     #XXX: should draw be exposed or fixed? should default to str?
     #XXX: should dist not default to None? (or have a rtol?)
-    npop = 8 #FIXME: change default, or expose this to the user???
-    draw = 'diffev'
+    smooth = 0 #XXX: expose this to the user?
+    npop = 8 #FIXME: change default? expose this to the user?
+    draw = 'diffev' if npop else 'fmin'
     # draw  --  if False, use npts largest error values, else use weighted draw
     # if draw is a mystic.solver, interpolate error and solve for npts maxima
     #
@@ -184,6 +185,7 @@ Notes: if clip is None, do not clip or resample (may exceed bounds)
         raise ValueError(msg)
     data = np.asarray(data)
     error = np.asarray(error)
+    #print(error)
     if mtol is None: mtol = 10 #NOTE: default is 0.1
     else: mtol = int(100 * mtol)
     if not len(error): # randomly select points (all error is the same)
@@ -208,9 +210,9 @@ Notes: if clip is None, do not clip or resample (may exceed bounds)
     idx = np.concatenate((idx, np.random.choice(len(error), size=pts, p=error/error.sum())))
     result = data[idx].tolist()
     if draw:
-        ## generate error model from sample points and values
+        # generate error model from sample points and values #XXX: len(error)>1
         from mystic.math.interpolate import interpf, _to_objective
-        error = interpf(data, error, 'thin_plate') #XXX requires len(error) > 1
+        error = interpf(data, error, 'thin_plate', smooth=smooth)
         error = _to_objective(error)
         bounds = list(zip(lb,ub))
         kwds = dict(bounds=bounds,disp=0,xtol=1e-8,ftol=1e-8,gtol=None)

--- a/mystic/monitors.py
+++ b/mystic/monitors.py
@@ -152,7 +152,7 @@ example usage...
 
     def __call__(self, x, y, id=None, **kwds):#, best=0):
         self._x.append(listify(x)) #XXX: listify?
-        _type = iter if hasattr(y, '__len__') else None
+        _type = iter if (hasattr(y, '__len__') and getattr(y, 'ndim', 1)) else None
         self._y.append(listify(self._k(y, _type))) #XXX: listify?
         self._id.append(id)
        #if not self._all and list_or_tuple_or_ndarray(x):

--- a/mystic/samplers.py
+++ b/mystic/samplers.py
@@ -8,7 +8,7 @@
 samplers: optimizer-guided directed sampling
 """
 __all__  = ['LatticeSampler','BuckshotSampler','SparsitySampler',\
-            'MisfitSampler','MixedSampler']
+            'ResidualSampler','MixedSampler']
 
 from mystic.abstract_sampler import AbstractSampler
 
@@ -57,19 +57,19 @@ optimizer-directed sampling starting at N points sampled in sparse reigons
         return s
 
 
-class MisfitSampler(AbstractSampler):
+class ResidualSampler(AbstractSampler):
     """
 optimizer-directed sampling starting at N points sampled near largest misfit
     """
     def __init__(self, bounds, model, npts=None, **kwds):
         self._mtol = kwds.pop('mtol', None)
-        super(MisfitSampler, self).__init__(bounds, model, npts, **kwds)
+        super(ResidualSampler, self).__init__(bounds, model, npts, **kwds)
         return
     __init__.__doc__ = AbstractSampler.__init__.__doc__
     def _init_solver(self, **kwd):
         """initialize the ensemble solver"""
-        from mystic.ensemble import MisfitSolver
-        s = MisfitSolver(len(self._bounds), npts=self._npts, mtol=self._mtol, func=self._model) #FIXME: TEST (mon?)
+        from mystic.ensemble import ResidualSolver
+        s = ResidualSolver(len(self._bounds), npts=self._npts, mtol=self._mtol, func=self._model) #FIXME: TEST (mon?)
         s.SetStrictRanges(*zip(*self._bounds), **kwd)
         s.SetObjective(self._model)
         return s

--- a/mystic/solvers.py
+++ b/mystic/solvers.py
@@ -24,7 +24,7 @@ and in each derived optimizer.  Mystic's optimizers are::
     BuckshotSolver               -- Uniform Random Distribution of N Solvers
     LatticeSolver                -- Distribution of N Solvers on a Regular Grid
     SparsitySolver               -- N Solvers Sampled where Point Density is Low
-    MisfitSolver                 -- N Solvers Sampled where Model Misfit is High
+    ResidualSolver               -- N Solvers Sampled where Model Misfit is High
     MixedSolver                  -- Mixture of N Pseudo-Global Optimizers
     ** Local-Search Optimizers **
     NelderMeadSimplexSolver      -- Nelder-Mead Simplex algorithm
@@ -47,7 +47,7 @@ are provided::
     buckshot    -- BuckshotSolver
     lattice     -- LatticeSolver
     sparsity    -- SparsitySolver
-    misfit      -- MisfitSolver
+    residual    -- ResidualSolver
     ** Local-Search Optimizers **
     fmin        -- NelderMeadSimplexSolver
     fmin_powell -- PowellDirectionalSolver
@@ -76,9 +76,9 @@ from mystic.differential_evolution import diffev, diffev2
 from mystic.ensemble import BuckshotSolver
 from mystic.ensemble import LatticeSolver
 from mystic.ensemble import SparsitySolver
-from mystic.ensemble import MisfitSolver
+from mystic.ensemble import ResidualSolver
 from mystic.ensemble import MixedSolver
-from mystic.ensemble import buckshot, lattice, sparsity, misfit
+from mystic.ensemble import buckshot, lattice, sparsity, residual
 
 # local-search optimizers
 from mystic.scipy_optimize import NelderMeadSimplexSolver

--- a/mystic/tests/test_boundsconstrained.py
+++ b/mystic/tests/test_boundsconstrained.py
@@ -14,7 +14,7 @@ from mystic.solvers import PowellDirectionalSolver, NelderMeadSimplexSolver, \
                            DifferentialEvolutionSolver, \
                            DifferentialEvolutionSolver2, \
                            LatticeSolver, BuckshotSolver, SparsitySolver, \
-                           MisfitSolver, MixedSolver
+                           ResidualSolver, MixedSolver
 
 almostEqual = my.math.almostEqual
 rosen = mm.rosen
@@ -71,9 +71,9 @@ test_constrained(DifferentialEvolutionSolver2, tight=None, clip=None)
 #test_constrained(SparsitySolver, tight=True, clip=None) #npts=8?
 #test_constrained(SparsitySolver, tight=True, clip=True)
 #test_constrained(SparsitySolver, tight=None, clip=None)
-#test_constrained(MisfitSolver, tight=True, clip=None) #npts=8?
-#test_constrained(MisfitSolver, tight=True, clip=True)
-#test_constrained(MisfitSolver, tight=None, clip=None)
+#test_constrained(ResidualSolver, tight=True, clip=None) #npts=8?
+#test_constrained(ResidualSolver, tight=True, clip=True)
+#test_constrained(ResidualSolver, tight=None, clip=None)
 #test_constrained(MixedSolver, tight=True, clip=None) #samp=8?
 #test_constrained(MixedSolver, tight=True, clip=True)
 #test_constrained(MixedSolver, tight=None, clip=None)

--- a/mystic/tests/test_ensemble.py
+++ b/mystic/tests/test_ensemble.py
@@ -26,7 +26,7 @@ def init_data():
     mon._y = (list(map(rosen, mon._x)) + np.random.normal(0,.05, size=ini)).tolist()
     return mon
 
-solvers = ['MisfitSolver', 'SparsitySolver', 'BuckshotSolver', 'LatticeSolver']
+solvers = ['ResidualSolver', 'SparsitySolver', 'BuckshotSolver', 'LatticeSolver']
 for solver in solvers:
     samp = {solver: (npts,)}
     solver = eval(solver)(ndim, *samp[solver])

--- a/mystic/tests/test_samplers.py
+++ b/mystic/tests/test_samplers.py
@@ -8,7 +8,7 @@
 from mystic.solvers import PowellDirectionalSolver
 from mystic.termination import NormalizedChangeOverGeneration as NCOG
 from mystic.samplers import (SparsitySampler, BuckshotSampler, LatticeSampler,
-                             MisfitSampler, MixedSampler)
+                             ResidualSampler, MixedSampler)
 from mystic.models import sphere as model
 from mystic.math import almostEqual
 x0 = [0,0,0,0]
@@ -18,7 +18,7 @@ N = 8
 
 
 for sampler in (SparsitySampler, BuckshotSampler, LatticeSampler,
-                MisfitSampler, MixedSampler):
+                ResidualSampler, MixedSampler):
     s = sampler(bounds, model, npts=N, id=0, maxiter=8000, maxfun=1e6,
                 solver=PowellDirectionalSolver, termination=NCOG(1e-6, 10))
     s.sample_until(terminated=all)


### PR DESCRIPTION
## Summary

Rename MisfitSolver to ResidualSolver, similarly for `MisfitSampler`,
and add args from `cache.archinve.read_func` to `cache.function.read`

## Checklist
**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Added relevant documentation that builds in sphinx without error.
- [ ] Added new features that are documented with examples.
- [ ] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [ ] Added rationale for any breakage of backwards compatibility.
