### PR TITLE
add noise to surrogate fit to avoid singular matrix

### DIFF
--- a/examples3/xrd_optML3.py
+++ b/examples3/xrd_optML3.py
@@ -56,7 +56,7 @@ loop.SetGenerationMonitor(tracker)
 while not loop.Terminated():
 
     # fit the surrogate to data in truth database
-    surrogate.fit(data=data)
+    surrogate.fit(data=data, noise=1e-8)
 
     # find the minimum of the surrogate
     results = diffev2(lambda x: surrogate(x), bounds, npop=20,

--- a/examples3/xrd_optML3c.py
+++ b/examples3/xrd_optML3c.py
@@ -75,7 +75,7 @@ loop.SetGenerationMonitor(tracker)
 while not loop.Terminated():
 
     # fit the surrogate to data in truth database
-    surrogate.fit(data=data)
+    surrogate.fit(data=data, noise=1e-8)
 
     # find the minimum of the surrogate
     results = diffev2(lambda x: surrogate(x), bounds, npop=20,

--- a/examples3/xrd_optML4.py
+++ b/examples3/xrd_optML4.py
@@ -58,7 +58,7 @@ loop.SetGenerationMonitor(tracker)
 while not loop.Terminated():
 
     # fit the surrogate to data in truth database
-    surrogate.fit(data=data)
+    surrogate.fit(data=data, noise=1e-8)
 
     # find the minimum of the surrogate
     results = diffev2(lambda x: surrogate(x), bounds, npop=20, gtol=500,

--- a/examples3/xrd_optML4s.py
+++ b/examples3/xrd_optML4s.py
@@ -68,7 +68,7 @@ while not loop.Terminated():
     # fit a new surrogate to data in truth database
     candidates = get_db('surrogate.db', type=file_archive)
     candidates.clear()
-    surrogate.fit(data=data)
+    surrogate.fit(data=data, noise=1e-8)
 
     # find the minimum of the surrogate
     surr = surrogate.sample(bounds, pts='-.%s' % N, archive=candidates,

--- a/examples3/xrd_optML4v.py
+++ b/examples3/xrd_optML4v.py
@@ -62,7 +62,7 @@ loop.SetGenerationMonitor(tracker)
 while not loop.Terminated():
 
     # fit the surrogate to data in truth database
-    surrogate.fit(data=data)
+    surrogate.fit(data=data, noise=1e-8)
 
     # find the first-order critical points of the surrogate
     s = SparsitySampler(bounds, lambda x: surrogate(x, axis=None), npts=N,

--- a/examples3/xrd_optML4vy.py
+++ b/examples3/xrd_optML4vy.py
@@ -62,7 +62,7 @@ loop.SetGenerationMonitor(tracker)
 while not loop.Terminated():
 
     # fit the surrogate to data in truth database
-    surrogate.fit(data=data)
+    surrogate.fit(data=data, noise=1e-8)
 
     # find the first-order critical points of the surrogate
     s = SparsitySampler(bounds, lambda x: surrogate(x, axis=None), npts=N,

--- a/examples3/xrd_optML4w.py
+++ b/examples3/xrd_optML4w.py
@@ -68,7 +68,7 @@ from mystic.cache.function import write as surrogatedb
 while not loop.Terminated():
 
     # fit the surrogate to data in truth database
-    surrogate.fit(data=data)
+    surrogate.fit(data=data, noise=1e-8)
     #[evalmon(xi,surrogate(xi)) for xi in xdata] # save latest data to monitor
     # save surrogate to archive
     surrogatedb(surrogate, 'function')

--- a/examples3/xrd_optML4wm.py
+++ b/examples3/xrd_optML4wm.py
@@ -68,7 +68,7 @@ from mystic.cache.function import write as surrogatedb
 while not loop.Terminated():
 
     # fit the surrogate to data in truth database
-    surrogate.fit(data=data)
+    surrogate.fit(data=data, noise=1e-8)
     #[evalmon(xi,surrogate(xi)) for xi in xdata] # save latest data to monitor
     # save surrogate to archive
     surrogatedb(surrogate, 'function')

--- a/examples3/xrd_optML4x.py
+++ b/examples3/xrd_optML4x.py
@@ -58,7 +58,7 @@ loop.SetGenerationMonitor(tracker)
 while not loop.Terminated():
 
     # fit the surrogate to data in truth database
-    surrogate.fit(data=data)
+    surrogate.fit(data=data, noise=1e-8)
 
     # find the first-order critical points of the surrogate
     surr_ = lambda x: surrogate(x, axis=None)

--- a/examples3/xrd_optML4xs.py
+++ b/examples3/xrd_optML4xs.py
@@ -62,7 +62,7 @@ while not loop.Terminated():
 
     # fit a new surrogate to data in truth database
     get_db('surrogate').clear()
-    surrogate.fit(data=data)
+    surrogate.fit(data=data, noise=1e-8)
 
     # find the first-order critical points of the surrogate
     surr = surrogate.sample(bounds, pts='.%s' % N)

--- a/examples3/xrd_optML4y.py
+++ b/examples3/xrd_optML4y.py
@@ -58,7 +58,7 @@ loop.SetGenerationMonitor(tracker)
 while not loop.Terminated():
 
     # fit the surrogate to data in truth database
-    surrogate.fit(data=data)
+    surrogate.fit(data=data, noise=1e-8)
 
     # find the minimum of the surrogate
     results = diffev2(lambda x: surrogate(x), bounds, npop=20, gtol=500,


### PR DESCRIPTION
## Summary
add a little noise to `surrogate.fit` when using `InterpModel` on a deterministic function. This helps avoid a SingularMatrix

