### PR TITLE
enable monitors to read lists of numpy float types

### DIFF
--- a/mystic/monitors.py
+++ b/mystic/monitors.py
@@ -66,7 +66,7 @@ __all__ = ['Null', 'Monitor', 'VerboseMonitor', 'LoggingMonitor',
 
 import os
 import sys
-import numpy
+import numpy; np = numpy
 from functools import reduce
 from mystic.tools import list_or_tuple_or_ndarray
 from mystic.tools import listify, _kdiv, _divide, _idivide, \


### PR DESCRIPTION
## Summary
if a list of NumPy float64 or similar types are written to a monitor (especially a logfile), reading the monitor will crash as NumPy needs to be imported.  Enable the read by importing NumPy (as np) before the read.
