### PR TITLE
use tolist in listify

### DIFF
--- a/examples3/xrd_optML4v.py
+++ b/examples3/xrd_optML4v.py
@@ -14,6 +14,7 @@ from mystic.samplers import SparsitySampler
 from mystic.monitors import LoggingMonitor
 from mystic.solvers import PowellDirectionalSolver
 from mystic.termination import NormalizedChangeOverGeneration as NCOG
+from mystic.tools import listify as tolist
 from ouq_models import WrapModel, InterpModel
 from emulators import cost4 as cost, x4 as target, bounds4 as bounds
 #from mystic.cache.archive import file_archive, read as get_db
@@ -71,7 +72,7 @@ while not loop.Terminated():
                         solver=PowellDirectionalSolver,
                         termination=NCOG(1e-6, 10))
     s.sample_until(terminated=all)
-    xdata = [list(i) for i in s._sampler._all_bestSolution]
+    xdata = tolist(s._sampler._all_bestSolution)
     ysurr = s._sampler._all_bestEnergy
 
     # evaluate truth at the same input as the surrogate critical points

--- a/examples3/xrd_optML4vy.py
+++ b/examples3/xrd_optML4vy.py
@@ -14,6 +14,7 @@ from mystic.samplers import SparsitySampler
 from mystic.monitors import LoggingMonitor
 from mystic.solvers import PowellDirectionalSolver
 from mystic.termination import NormalizedChangeOverGeneration as NCOG
+from mystic.tools import listify as tolist
 from ouq_models import WrapModel, InterpModel
 from emulators import cost4 as cost, x4 as target, bounds4 as bounds
 #from mystic.cache.archive import file_archive, read as get_db
@@ -71,7 +72,7 @@ while not loop.Terminated():
                         solver=PowellDirectionalSolver,
                         termination=NCOG(1e-6, 10))
     s.sample_until(terminated=all)
-    xdata = [list(i) for i in s._sampler._all_bestSolution]
+    xdata = tolist(s._sampler._all_bestSolution)
     ysurr = s._sampler._all_bestEnergy
 
     # evaluate truth at the same input as the surrogate critical points

--- a/examples3/xrd_optML4w.py
+++ b/examples3/xrd_optML4w.py
@@ -14,6 +14,7 @@ from mystic.samplers import SparsitySampler
 from mystic.monitors import Monitor, LoggingMonitor
 from mystic.solvers import PowellDirectionalSolver
 from mystic.termination import NormalizedChangeOverGeneration as NCOG
+from mystic.tools import listify as tolist
 from ouq_models import WrapModel, InterpModel
 from emulators import cost4 as cost, x4 as target, bounds4 as bounds
 #from mystic.cache.archive import file_archive, read as get_db
@@ -83,7 +84,7 @@ while not loop.Terminated():
     s.sample_until(terminated=all)
 
     # get surrogate at critical points
-    xdata = [list(i) for i in s._sampler._all_bestSolution]
+    xdata = tolist(s._sampler._all_bestSolution)
     ysurr = s._sampler._all_bestEnergy
 
     # evaluate truth at the same input as the surrogate critical points

--- a/examples3/xrd_optML4wm.py
+++ b/examples3/xrd_optML4wm.py
@@ -14,6 +14,7 @@ from mystic.samplers import ResidualSampler
 from mystic.monitors import Monitor, LoggingMonitor
 from mystic.solvers import PowellDirectionalSolver
 from mystic.termination import NormalizedChangeOverGeneration as NCOG
+from mystic.tools import listify as tolist
 from ouq_models import WrapModel, InterpModel
 from emulators import cost4 as cost, x4 as target, bounds4 as bounds
 #from mystic.cache.archive import file_archive, read as get_db
@@ -83,7 +84,7 @@ while not loop.Terminated():
     s.sample_until(terminated=all)
 
     # get surrogate at critical points
-    xdata = [list(i) for i in s._sampler._all_bestSolution]
+    xdata = tolist(s._sampler._all_bestSolution)
     ysurr = s._sampler._all_bestEnergy
 
     # evaluate truth at the same input as the surrogate critical points

--- a/examples3/xrd_optML4x.py
+++ b/examples3/xrd_optML4x.py
@@ -12,6 +12,7 @@ optimization of 4-input cost function using online learning of a surrogate
 import os
 from mystic.samplers import LatticeSampler
 from mystic.monitors import LoggingMonitor
+from mystic.tools import listify as tolist
 from ouq_models import WrapModel, InterpModel
 from emulators import cost4 as cost, x4 as target, bounds4 as bounds
 #from mystic.cache.archive import file_archive, read as get_db
@@ -64,13 +65,13 @@ while not loop.Terminated():
     surr_ = lambda x: surrogate(x, axis=None)
     s = LatticeSampler(bounds, surr_, npts=N)
     s.sample_until(terminated=all)
-    xdata = [list(i) for i in s._sampler._all_bestSolution]
+    xdata = tolist(s._sampler._all_bestSolution)
     ysurr = s._sampler._all_bestEnergy
 
     _surr = lambda x: -surrogate(x, axis=None)
     s_ = LatticeSampler(bounds, _surr, npts=N)
     s_.sample_until(terminated=all)
-    xdata = xdata + [list(i) for i in s_._sampler._all_bestSolution]
+    xdata = xdata + tolist(s_._sampler._all_bestSolution)
     ysurr = ysurr + [-i for i in s_._sampler._all_bestEnergy]
 
     # evaluate truth at the same input as the surrogate critical points

--- a/mystic/tools.py
+++ b/mystic/tools.py
@@ -250,6 +250,7 @@ def is_zero_d_ndarray(x):
 
 def listify(x):
     "recursively convert all members of a sequence to a list"
+    if hasattr(x, 'tolist'): return x.tolist()
     if not isiterable(x): return x
     if x is iter(x): return listify(list(x))
     try: # e.g. if array(1)


### PR DESCRIPTION
## Summary
use `tolist` in `listify` for speed, and to avoid lists of `np.float64`
use `listify` in optML on `xdata`

## Checklist
**Documentation and Tests**
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [ ] Added rationale for any breakage of backwards compatibility.
