### PR TITLE
add new RBFs, fix missing import, update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
             - DILL="master"
             - KLEPTO="master"
 
-        - python: 'pypy3.9-7.3.9' # at 7.3.16
+        - python: 'pypy3.9-7.3.15' # at 7.3.16
           env:
 
         - python: 'pypy3.10-7.3.19'
@@ -38,8 +38,7 @@ matrix:
           env:
 
     allow_failures:
-        - python: '3.14-dev' # CI missing
-        - python: 'pypy3.10-7.3.19' # CI missing
+        - python: '3.14-dev' # prerelease
         - python: 'pypy3.11-7.3.19' # CI missing
     fast_finish: true
 

--- a/examples3/dataset.py
+++ b/examples3/dataset.py
@@ -48,7 +48,8 @@ def interpolate(data, step=None, **kwds):
       if scipy is not installed, will use np.interp for 1D (non-rbf),
       or mystic's rbf otherwise. default method is 'nearest' for
       1D and 'linear' otherwise. method can be one of ('rbf','linear',
-      'nearest','cubic','inverse','gaussian','quintic','thin_plate').
+      'nearest','cubic','inverse','gaussian','quintic','thin_plate',
+      'bump', 'hyperbolic', 'quartic', 'inverse_quadratic').
 
     NOTE:
       additional keyword arguments (epsilon, smooth, norm) are avaiable
@@ -100,7 +101,8 @@ def distance(data, function=None, hausdorff=True, **kwds):
       if scipy is not installed, will use np.interp for 1D (non-rbf),
       or mystic's rbf otherwise. default method is 'nearest' for
       1D and 'linear' otherwise. method can be one of ('rbf','linear',
-      'nearest','cubic','inverse','gaussian','quintic','thin_plate').
+      'nearest','cubic','inverse','gaussian','quintic','thin_plate',
+      'bump', 'hyperbolic', 'quartic', 'inverse_quadratic').
 
     NOTE:
       data and function may provide tuple-valued or single-valued output.

--- a/examples3/interpolator.py
+++ b/examples3/interpolator.py
@@ -49,7 +49,8 @@ class Interpolator(object):
           if scipy is not installed, will use np.interp for 1D (non-rbf),
           or mystic's rbf otherwise. default method is 'nearest' for
           1D and 'linear' otherwise. method can be one of ('rbf','linear',
-          'nearest','cubic','inverse','gaussian','quintic','thin_plate').
+          'nearest','cubic','inverse','gaussian','quintic','thin_plate',
+          'bump', 'hyperbolic', 'quartic', 'inverse_quadratic').
 
         NOTE:
           additional keyword arguments (epsilon, smooth, norm) are avaiable
@@ -138,7 +139,8 @@ class Interpolator(object):
           if scipy is not installed, will use np.interp for 1D (non-rbf),
           or mystic's rbf otherwise. default method is 'nearest' for
           1D and 'linear' otherwise. method can be one of ('rbf','linear',
-          'nearest','cubic','inverse','gaussian','quintic','thin_plate').
+          'nearest','cubic','inverse','gaussian','quintic','thin_plate',
+          'bump', 'hyperbolic', 'quartic', 'inverse_quadratic').
 
         NOTE:
           additional keyword arguments (epsilon, smooth, norm) are avaiable
@@ -174,7 +176,8 @@ class Interpolator(object):
           if scipy is not installed, will use np.interp for 1D (non-rbf),
           or mystic's rbf otherwise. default method is 'nearest' for
           1D and 'linear' otherwise. method can be one of ('rbf','linear',
-          'nearest','cubic','inverse','gaussian','quintic','thin_plate').
+          'nearest','cubic','inverse','gaussian','quintic','thin_plate',
+          'bump', 'hyperbolic', 'quartic', 'inverse_quadratic').
 
         NOTE:
           additional keyword arguments (epsilon, smooth, norm) are avaiable
@@ -260,7 +263,8 @@ def interpolate(monitor, method=None, **kwds):
       if scipy is not installed, will use np.interp for 1D (non-rbf),
       or mystic's rbf otherwise. default method is 'nearest' for
       1D and 'linear' otherwise. method can be one of ('rbf','linear',
-      'nearest','cubic','inverse','gaussian','quintic','thin_plate').
+      'nearest','cubic','inverse','gaussian','quintic','thin_plate',
+      'bump', 'hyperbolic', 'quartic', 'inverse_quadratic').
 
     NOTE:
       additional keyword arguments (epsilon, smooth, norm) are avaiable

--- a/examples3/ouq_models.py
+++ b/examples3/ouq_models.py
@@ -507,7 +507,8 @@ class OUQModel(object): #NOTE: effectively, this is WrapModel
       if scipy is not installed, will use np.interp for 1D (non-rbf),
       or mystic's rbf otherwise. default method is 'nearest' for
       1D and 'linear' otherwise. method can be one of ('rbf','linear',
-      'nearest','cubic','inverse','gaussian','quintic','thin_plate').
+      'nearest','cubic','inverse','gaussian','quintic','thin_plate',
+      'bump', 'hyperbolic', 'quartic', 'inverse_quadratic').
 
     NOTE:
       data and function may provide tuple-valued or single-valued output.

--- a/examples3/plotter.py
+++ b/examples3/plotter.py
@@ -38,7 +38,8 @@ class Plotter(object):
           if scipy is not installed, will use np.interp for 1D (non-rbf),
           or mystic's rbf otherwise. default method is 'nearest' for
           1D and 'linear' otherwise. method can be one of ('rbf','linear',
-          'nearest','cubic','inverse','gaussian','quintic','thin_plate').
+          'nearest','cubic','inverse','gaussian','quintic','thin_plate',
+          'bump', 'hyperbolic', 'quartic', 'inverse_quadratic').
         """
         self.x = getattr(x, '_x', x)  # params (x)
         self.z = x._y if z is None else z # cost (f(x))
@@ -273,7 +274,8 @@ def plot(monitor, function=None, **kwds):
       if scipy is not installed, will use np.interp for 1D (non-rbf),
       or mystic's rbf otherwise. default method is 'nearest' for
       1D and 'linear' otherwise. method can be one of ('rbf','linear',
-      'nearest','cubic','inverse','gaussian','quintic','thin_plate').
+      'nearest','cubic','inverse','gaussian','quintic','thin_plate',
+      'bump', 'hyperbolic', 'quartic', 'inverse_quadratic').
     '''
     p = Plotter(monitor, function=function, **kwds)
     p.Plot()

--- a/examples3/surface.py
+++ b/examples3/surface.py
@@ -64,7 +64,8 @@ class Surface(object): #FIXME: should be subclass of Interpolator (?)
           if scipy is not installed, will use np.interp for 1D (non-rbf),
           or mystic's rbf otherwise. default method is 'nearest' for
           1D and 'linear' otherwise. method can be one of ('rbf','linear',
-          'nearest','cubic','inverse','gaussian','quintic','thin_plate').
+          'nearest','cubic','inverse','gaussian','quintic','thin_plate',
+          'bump', 'hyperbolic', 'quartic', 'inverse_quadratic').
         """
         # sampler configuration
         from mystic.search import Searcher
@@ -245,7 +246,8 @@ class Surface(object): #FIXME: should be subclass of Interpolator (?)
           if scipy is not installed, will use np.interp for 1D (non-rbf),
           or mystic's rbf otherwise. default method is 'nearest' for
           1D and 'linear' otherwise. method can be one of ('rbf','linear',
-          'nearest','cubic','inverse','gaussian','quintic','thin_plate').
+          'nearest','cubic','inverse','gaussian','quintic','thin_plate',
+          'bump', 'hyperbolic', 'quartic', 'inverse_quadratic').
         """
         from interpolator import Interpolator
         args = self.args.copy()

--- a/mystic/math/interpolate.py
+++ b/mystic/math/interpolate.py
@@ -38,7 +38,8 @@ def extrapolate(x, z=None, method=None, mins=None, maxs=None, **kwds):
         ``method='thin_plate'`` (or ``'rbf'`` if ``scipy`` is not found).
         If ``method`` is False, return the original input. Alternately,
         ``method`` can be any one of ``('rbf', 'linear', 'cubic', 'nearest',
-        'inverse', 'gaussian', 'multiquadric', 'quintic', 'thin_plate')``.
+        'inverse', 'gaussian', 'multiquadric', 'quintic', 'thin_plate',
+        'bump', 'hyperbolic', 'quartic', 'inverse_quadratic')``.
         If ``method`` is None, return ``nan`` upon new input.
     '''
     kwds.setdefault('all', True)
@@ -431,11 +432,13 @@ def interpolate(x, z, xgrid, method=None, extrap=False, arrays=True, **kwds):
         (non-rbf), or ``rbf`` from ``mystic`` otherwise. Default method is
         ``'nearest'`` for 1D, and is ``'linear'`` otherwise. ``method`` can
         be one of ``('rbf', 'linear', 'cubic', 'nearest', 'inverse',
-        'gaussian', 'multiquadric', 'quintic', 'thin_plate')``.
+        'gaussian', 'multiquadric', 'quintic', 'thin_plate', 'bump',
+        'hyperbolic', 'quartic', 'inverse_quadratic')``.
       - if ``extrap`` is True, extrapolate using ``interpf`` with 
         ``method='thin_plate'`` (or ``'rbf'`` if ``scipy`` is not installed).
         Alternately, any one of ``('rbf', 'linear', 'cubic', 'nearest',
-        'inverse', 'gaussian', 'multiquadric', 'quintic', 'thin_plate')`` can
+        'inverse', 'gaussian', 'multiquadric', 'quintic', 'thin_plate',
+        'bump', 'hyperbolic', 'quartic', 'inverse_quadratic')`` can
         be used. If ``extrap`` is a cost function ``z = f(x)``, then directly
         use it in the extrapolation. Using extrapolation can reduce the number
         of ``nan``.
@@ -455,6 +458,7 @@ def interpolate(x, z, xgrid, method=None, extrap=False, arrays=True, **kwds):
     methods = dict(rbf=0, linear=1, nearest=2, cubic=3)
     functions = {0:'multiquadric', 1:'linear', 2:'nearest', 3:'cubic'}
     # also: ['thin_plate','inverse','gaussian','quintic']
+    # also: ['inverse_quadratic','bump','quartic','hyperbolic']
     kind = methods[method] if method in methods else None
     function = functions[kind] if (not kind is None) else method
     if kind is None: kind = 0 #XXX: or raise KeyError ?
@@ -501,11 +505,13 @@ def _interpf(x, z, method=None, extrap=False, arrays=False, **kwds):
         (non-rbf), or ``rbf`` from ``mystic`` otherwise. Default method is
         ``'nearest'`` for 1D, and is ``'linear'`` otherwise. ``method`` can
         be one of ``('rbf', 'linear', 'cubic', 'nearest', 'inverse',
-        'gaussian', 'multiquadric', 'quintic', 'thin_plate')``.
+        'gaussian', 'multiquadric', 'quintic', 'thin_plate', 'bump',
+        'hyperbolic', 'quartic', 'inverse_quadratic')``.
       - if ``extrap`` is True, extrapolate using ``interpf`` with 
         ``method='thin_plate'`` (or ``'rbf'`` if ``scipy`` is not installed).
         Alternately, any one of ``('rbf', 'linear', 'cubic', 'nearest',
-        'inverse', 'gaussian', 'multiquadric', 'quintic', 'thin_plate')`` can
+        'inverse', 'gaussian', 'multiquadric', 'quintic', 'thin_plate',
+        'bump', 'hyperbolic', 'quartic', 'inverse_quadratic')`` can
         be used. If ``extrap`` is a cost function ``z = f(x)``, then directly
         use it in the extrapolation. Using extrapolation can reduce the number
         of ``nan``.
@@ -527,6 +533,7 @@ def _interpf(x, z, method=None, extrap=False, arrays=False, **kwds):
     methods = dict(rbf=0, linear=1, nearest=2, cubic=3)
     functions = {0:'multiquadric', 1:'linear', 2:'nearest', 3:'cubic'}
     # also: ['thin_plate','inverse','gaussian','quintic']
+    # also: ['inverse_quadratic','bump','quartic','hyperbolic']
     kind = methods[method] if method in methods else None
     function = functions[kind] if (not kind is None) else method
     if kind is None: kind = 0 #XXX: or raise KeyError ?
@@ -608,11 +615,13 @@ def interpf(x, z, method=None, extrap=False, arrays=False, **kwds):
         (non-rbf), or ``rbf`` from ``mystic`` otherwise. Default method is
         ``'nearest'`` for 1D, and is ``'linear'`` otherwise. ``method`` can
         be one of ``('rbf', 'linear', 'cubic', 'nearest', 'inverse',
-        'gaussian', 'multiquadric', 'quintic', 'thin_plate')``.
+        'gaussian', 'multiquadric', 'quintic', 'thin_plate', 'bump',
+        'hyperbolic', 'quartic', 'inverse_quadratic')``.
       - if ``extrap`` is True, extrapolate using ``interpf`` with 
         ``method='thin_plate'`` (or ``'rbf'`` if ``scipy`` is not installed).
         Alternately, any one of ``('rbf', 'linear', 'cubic', 'nearest',
-        'inverse', 'gaussian', 'multiquadric', 'quintic', 'thin_plate')`` can
+        'inverse', 'gaussian', 'multiquadric', 'quintic', 'thin_plate',
+        'bump', 'hyperbolic', 'quartic', 'inverse_quadratic')`` can
         be used. If ``extrap`` is a cost function ``z = f(x)``, then directly
         use it in the extrapolation. Using extrapolation can reduce the number
         of ``nan``.
@@ -705,7 +714,8 @@ def _fprime(x, fx, method=None, extrap=False, **kwds):
       - if ``extrap`` is True, extrapolate using ``interpf`` with 
         ``method='thin_plate'`` (or ``'rbf'`` if ``scipy`` is not installed).
         Alternately, any one of ``('rbf', 'linear', 'cubic', 'nearest',
-        'inverse', 'gaussian', 'multiquadric', 'quintic', 'thin_plate')`` can
+        'inverse', 'gaussian', 'multiquadric', 'quintic', 'thin_plate',
+        'bump', 'hyperbolic', 'quartic', 'inverse_quadratic')`` can
         be used. If ``extrap`` is a cost function ``z = f(x)``, then directly
         use it in the extrapolation. Using extrapolation can reduce the number
         of ``nan``.
@@ -759,11 +769,13 @@ def gradient(x, fx, method=None, approx=True, extrap=False, **kwds):
         (non-rbf), or ``rbf`` from ``mystic`` otherwise. Default method is
         ``'nearest'`` for 1D, and is ``'linear'`` otherwise. ``method`` can
         be one of ``('rbf', 'linear', 'cubic', 'nearest', 'inverse',
-        'gaussian', 'multiquadric', 'quintic', 'thin_plate')``.
+        'gaussian', 'multiquadric', 'quintic', 'thin_plate', 'bump',
+        'hyperbolic', 'quartic', 'inverse_quadratic')``.
       - if ``extrap`` is True, extrapolate using ``interpf`` with 
         ``method='thin_plate'`` (or ``'rbf'`` if ``scipy`` is not installed).
         Alternately, any one of ``('rbf', 'linear', 'cubic', 'nearest',
-        'inverse', 'gaussian', 'multiquadric', 'quintic', 'thin_plate')`` can
+        'inverse', 'gaussian', 'multiquadric', 'quintic', 'thin_plate',
+        'bump', 'hyperbolic', 'quartic', 'inverse_quadratic')`` can
         be used. If ``extrap`` is a cost function ``z = f(x)``, then directly
         use it in the extrapolation. Using extrapolation can reduce the number
         of ``nan``.
@@ -853,7 +865,8 @@ def hessian(x, fx, method=None, approx=True, extrap=False, **kwds):
         (non-rbf), or ``rbf`` from ``mystic`` otherwise. Default method is
         ``'nearest'`` for 1D, and is ``'linear'`` otherwise. ``method`` can
         be one of ``('rbf', 'linear', 'cubic', 'nearest', 'inverse',
-        'gaussian', 'multiquadric', 'quintic', 'thin_plate')``.
+        'gaussian', 'multiquadric', 'quintic', 'thin_plate', 'bump',
+        'hyperbolic', 'quartic', 'inverse_quadratic')``.
       - method string can provide either one or two methods (i.e. ``'rbf'``
         or ``'rbf, cubic'``), where if two methods are provided, the first
         will be used to interpolate ``f(x)`` and the second will be used to
@@ -861,7 +874,8 @@ def hessian(x, fx, method=None, approx=True, extrap=False, **kwds):
       - if ``extrap`` is True, extrapolate using ``interpf`` with 
         ``method='thin_plate'`` (or ``'rbf'`` if ``scipy`` is not installed).
         Alternately, any one of ``('rbf', 'linear', 'cubic', 'nearest',
-        'inverse', 'gaussian', 'multiquadric', 'quintic', 'thin_plate')`` can
+        'inverse', 'gaussian', 'multiquadric', 'quintic', 'thin_plate',
+        'bump', 'hyperbolic', 'quartic', 'inverse_quadratic')`` can
         be used. If ``extrap`` is a cost function ``z = f(x)``, then directly
         use it in the extrapolation. Using extrapolation can reduce the number
         of ``nan``.
@@ -925,11 +939,13 @@ def hessian_diagonal(x, fx, method=None, approx=True, extrap=False, **kwds):
         (non-rbf), or ``rbf`` from ``mystic`` otherwise. Default method is
         ``'nearest'`` for 1D, and is ``'linear'`` otherwise. ``method`` can
         be one of ``('rbf', 'linear', 'cubic', 'nearest', 'inverse',
-        'gaussian', 'multiquadric', 'quintic', 'thin_plate')``.
+        'gaussian', 'multiquadric', 'quintic', 'thin_plate', 'bump',
+        'hyperbolic', 'quartic', 'inverse_quadratic')``.
       - if ``extrap`` is True, extrapolate using ``interpf`` with 
         ``method='thin_plate'`` (or ``'rbf'`` if ``scipy`` is not installed).
         Alternately, any one of ``('rbf', 'linear', 'cubic', 'nearest',
-        'inverse', 'gaussian', 'multiquadric', 'quintic', 'thin_plate')`` can
+        'inverse', 'gaussian', 'multiquadric', 'quintic', 'thin_plate',
+        'bump', 'hyperbolic', 'quartic', 'inverse_quadratic')`` can
         be used. If ``extrap`` is a cost function ``z = f(x)``, then directly
         use it in the extrapolation. Using extrapolation can reduce the number
         of ``nan``.

--- a/mystic/models/schittkowski.py
+++ b/mystic/models/schittkowski.py
@@ -22,6 +22,7 @@ __all__ = ['Paviani', 'paviani']
 
 from .abstract_model import AbstractFunction
 
+from functools import reduce
 from math import sin, cos, sqrt, pi, exp, log
 from numpy import inf
 

--- a/mystic/tests/test_interpolate.py
+++ b/mystic/tests/test_interpolate.py
@@ -18,15 +18,19 @@ y = cost(x.T)
 
 import mystic.math.interpolate as ip
 
-# functions which are 1 at r = 0 reproduce a single datapoint
+# functions which are non-zero at r = 0 reproduce a single datapoint
 fx = ip.Rbf(*np.vstack((x.T, y)), function='gaussian', smooth=0.0)
 assert (fx(*x.T) - y).sum() == 0.0
 fx = ip.Rbf(*np.vstack((x.T, y)), function='multiquadric', smooth=0.0)
 assert (fx(*x.T) - y).sum() == 0.0
 fx = ip.Rbf(*np.vstack((x.T, y)), function='inverse', smooth=0.0)
 assert (fx(*x.T) - y).sum() == 0.0
+fx = ip.Rbf(*np.vstack((x.T, y)), function='inverse_quadratic', smooth=0.0)
+assert (fx(*x.T) - y).sum() == 0.0
+fx = ip.Rbf(*np.vstack((x.T, y)), function='bump', smooth=0.0)
+assert (fx(*x.T) - y).sum() == 0.0
 
-# functions which are 0 at r = 0 are singular with a single datapoint
+# functions which are zero at r = 0 are singular with a single datapoint
 fx = ip.Rbf(*np.vstack((x.T, y)), function='linear', smooth=-1e-100)
 assert fx(*x.T).sum() == 0.0
 fx = ip.Rbf(*np.vstack((x.T, y)), function='cubic', smooth=-1e-100)
@@ -35,4 +39,7 @@ fx = ip.Rbf(*np.vstack((x.T, y)), function='quintic', smooth=-1e-100)
 assert fx(*x.T).sum() == 0.0
 fx = ip.Rbf(*np.vstack((x.T, y)), function='thin_plate', smooth=-1e-100)
 assert fx(*x.T).sum() == 0.0
-
+fx = ip.Rbf(*np.vstack((x.T, y)), function='quartic', smooth=-1e-100)
+assert fx(*x.T).sum() == 0.0
+fx = ip.Rbf(*np.vstack((x.T, y)), function='hyperbolic', smooth=-1e-100)
+assert fx(*x.T).sum() == 0.0


### PR DESCRIPTION
## Summary
fix missing import of reduce from functools in schittkowski

update pypy versions used in travis.yml

add new RBFs (bump, inverse_quadratic, quintic, hyperbolic) in interpolate

## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Added relevant documentation that builds in sphinx without error.
- [x] Added new features that are documented with examples.
- [x] Artifacts produced with the main branch work as expected under this PR.