### PR TITLE
solve can use one-liners, measures ensemble solvers

### DIFF
--- a/mystic/constraints.py
+++ b/mystic/constraints.py
@@ -403,31 +403,32 @@ NOTE: The default solver is 'diffev', with npop=min(40, ndim*5). The default
 
     #XXX: don't allow solver string as a short-cut?
     ensemble = False
-    if solver is None or solver == 'diffev':
+    if solver is None or getattr(solver, '__name__', solver) == 'diffev':
         from mystic.solvers import DifferentialEvolutionSolver as TheSolver
         solver = TheSolver(ndim, min(40, ndim*5))
-    elif solver == 'diffev2':
+    elif getattr(solver, '__name__', solver) == 'diffev2':
         from mystic.solvers import DifferentialEvolutionSolver2 as TheSolver
         solver = TheSolver(ndim, min(40, ndim*5))
-    elif solver == 'fmin_powell': #XXX: better as the default? (it's not random)
+    #XXX: fmin_powell better as the default? (it's not random)
+    elif getattr(solver, '__name__', solver) == 'fmin_powell':
         from mystic.solvers import PowellDirectionalSolver as TheSolver
         solver = TheSolver(ndim)
-    elif solver == 'fmin':
+    elif getattr(solver, '__name__', solver) == 'fmin':
         from mystic.solvers import NelderMeadSimplexSolver as TheSolver
         solver = TheSolver(ndim)
-    elif solver == 'buckshot':
+    elif getattr(solver, '__name__', solver) == 'buckshot':
         from mystic.solvers import BuckshotSolver as TheSolver
         solver = TheSolver(ndim, max(8, npts)) #XXX: needs better default?
         ensemble = True
-    elif solver == 'lattice':
+    elif getattr(solver, '__name__', solver) == 'lattice':
         from mystic.solvers import LatticeSolver as TheSolver
         solver = TheSolver(ndim, max(8, npts)) #XXX: needs better default?
         ensemble = True
-    elif solver == 'sparsity':
+    elif getattr(solver, '__name__', solver) == 'sparsity':
         from mystic.solvers import SparsitySolver as TheSolver
         solver = TheSolver(ndim, max(8, npts)) #XXX: needs better default?
         ensemble = True
-    elif solver == 'residual':
+    elif getattr(solver, '__name__', solver) == 'residual':
         from mystic.solvers import ResidualSolver as TheSolver
         solver = TheSolver(ndim, max(8, npts)) #XXX: needs better default?
         ensemble = True

--- a/mystic/math/measures.py
+++ b/mystic/math/measures.py
@@ -1395,6 +1395,18 @@ def impose_reweighted_mean(m, samples, weights=None, solver=None):
         from mystic.solvers import diffev as solver
     elif solver == 'diffev2':
         from mystic.solvers import diffev2 as solver
+    elif getattr(solver, '__name__', solver) == 'buckshot':
+        from mystic.solvers import buckshot as solver
+        weights = ndim
+    elif getattr(solver, '__name__', solver) == 'lattice':
+        from mystic.solvers import lattice as solver
+        weights = ndim
+    elif getattr(solver, '__name__', solver) == 'sparsity':
+        from mystic.solvers import sparsity as solver
+        weights = ndim
+    elif getattr(solver, '__name__', solver) == 'residual':
+        from mystic.solvers import residual as solver
+        weights = ndim
 
     inequality = ""; equality = ""; equality2 = ""
     for i in range(ndim):
@@ -1441,6 +1453,18 @@ def impose_reweighted_variance(v, samples, weights=None, solver=None):
         from mystic.solvers import diffev as solver
     elif solver == 'diffev2':
         from mystic.solvers import diffev2 as solver
+    elif getattr(solver, '__name__', solver) == 'buckshot':
+        from mystic.solvers import buckshot as solver
+        weights = ndim
+    elif getattr(solver, '__name__', solver) == 'lattice':
+        from mystic.solvers import lattice as solver
+        weights = ndim
+    elif getattr(solver, '__name__', solver) == 'sparsity':
+        from mystic.solvers import sparsity as solver
+        weights = ndim
+    elif getattr(solver, '__name__', solver) == 'residual':
+        from mystic.solvers import residual as solver
+        weights = ndim
 
     inequality = ""
     equality = ""; equality2 = ""; equality3 = ""


### PR DESCRIPTION
## Summary
mystic.constraints.solve can use one-liners, similarly for mystic.constraints.as_constraint

mystic.math.measures can use ensemble solvers
