### PR TITLE
Fix bare except clauses in abstract_solver.py, constraints.py, and monitors.py

### DIFF
--- a/mystic/abstract_solver.py
+++ b/mystic/abstract_solver.py
@@ -557,7 +557,7 @@ Notes:
         else:
             try: # scalar ?
                 float(var)
-            except: # nope. var better be matrix of the right size (no check)
+            except (TypeError, ValueError): # nope. var better be matrix of the right size (no check)
                 pass
             else:
                 var = var * numpy.eye(self.nDim)

--- a/mystic/constraints.py
+++ b/mystic/constraints.py
@@ -346,7 +346,7 @@ Examples:
     else: # is a constraints solver
         try:
             constrained = guess.copy()
-        except:
+        except AttributeError:
             from copy import deepcopy
             constrained = deepcopy(guess)
         error = 0.0

--- a/mystic/monitors.py
+++ b/mystic/monitors.py
@@ -640,7 +640,7 @@ sys.modules.pop('{base}', None);
         params = _globals['___params'] if '___params' in _globals else None
         cost = _globals['___cost'] if '___cost' in _globals else None
         del _globals
-    except: #XXX: should only catch the appropriate exceptions
+    except Exception: #XXX: should only catch the appropriate exceptions
         raise OSError("error reading '{path}'".format(path=path))
 
     finally:


### PR DESCRIPTION
Fix bare `except:` clauses that catch `BaseException`, replacing them with specific exception types.

**`mystic/abstract_solver.py`** (line 560):
`except:` → `except (TypeError, ValueError):` — wraps `float(var)` which can raise `TypeError` (non-numeric) or `ValueError` (bad literal).

**`mystic/constraints.py`** (line 349):
`except:` → `except AttributeError:` — wraps `guess.copy()` which raises `AttributeError` when the object has no `.copy()` method.

**`mystic/monitors.py`** (line 643):
`except:` → `except Exception:` — wraps `exec(code, _globals)` which can raise various exceptions at runtime.

Bare `except:` clauses are bad practice (PEP 8 / flake8 E722) because they silently swallow `KeyboardInterrupt` and `SystemExit`, making programs uninterruptible.